### PR TITLE
Adding model export capability and inference within libTorch, and ONNX Runtime on CUDA and DNNL (oneDNN) backends.

### DIFF
--- a/Models/exports/README.md
+++ b/Models/exports/README.md
@@ -2,4 +2,4 @@
 A script to load the SceneSeg network checkpoint file, trace and then export as a *.pt file.
 
 ## Instructions
-python3 traced_script_module_save.py -p _network_checkpoint_file_name.pth_ -i _test_image_file_name.png_ -o _output_trace_file_name.pt_
+python3 traced_script_module_save.py -p <_network_checkpoint_file_name.pth_> -i <_test_image_file_name.png_> -o <_output_trace_file_name.pt_>

--- a/Models/exports/README.md
+++ b/Models/exports/README.md
@@ -1,5 +1,5 @@
 # SceneSeg Trace and Save
-A script to load the SceneSeg network checkpoint file, trace and then export as a *.pt file.
+A script to load the SceneSeg network checkpoint file, trace and then export as a *.pt file , and an *.onnx file.
 
 ## Instructions
-python3 traced_script_module_save.py -p <_network_checkpoint_file_name.pth_> -i <_test_image_file_name.png_> -o <_output_trace_file_name.pt_>
+python3 traced_script_module_save.py -p <_network_checkpoint_file_name.pth_> -i <_test_image_file_name.png_> -o1 <_pt_output_trace_file_name.pt_> -o2 <_onnx_output_trace_file_name.onnx_>

--- a/Models/exports/README.md
+++ b/Models/exports/README.md
@@ -2,4 +2,7 @@
 A script to load the SceneSeg network checkpoint file, trace and then export as a *.pt file , and an *.onnx file.
 
 ## Instructions
+The script can be run with the following command line arguments:
+```
 python3 traced_script_module_save.py -p <_network_checkpoint_file_name.pth_> -i <_test_image_file_name.png_> -o1 <_pt_output_trace_file_name.pt_> -o2 <_onnx_output_trace_file_name.onnx_>
+```

--- a/Models/exports/README.md
+++ b/Models/exports/README.md
@@ -1,0 +1,5 @@
+# SceneSeg Trace and Save
+A script to load the SceneSeg network checkpoint file, trace and then export as a *.pt file.
+
+## Instructions
+python3 traced_script_module_save.py -p _network_checkpoint_file_name.pth_ -i _test_image_file_name.png_ -o _output_trace_file_name.pt_

--- a/Models/exports/libtorch/CMakeLists.txt
+++ b/Models/exports/libtorch/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+project(deploy_libtorch)
+
+## These should be variables (TODO)
+set(USE_CUDNN ON)
+set(CAFFE2_USE_CUDNN ON)
+set(USE_CUSPARSELT OFF)
+
+## Find libTorch installation
+find_package(Torch REQUIRED HINTS ${LIBTORCH_INSTALL_ROOT}/share/cmake/Torch/ QUIET)
+
+## Build & Link
+add_executable(deploy_libtorch main.cpp)
+target_link_libraries(deploy_libtorch "${TORCH_LIBRARIES}")

--- a/Models/exports/libtorch/CMakeLists.txt
+++ b/Models/exports/libtorch/CMakeLists.txt
@@ -2,13 +2,19 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(deploy_libtorch)
 
 ## These should be variables (TODO)
-set(USE_CUDNN ON)
-set(CAFFE2_USE_CUDNN ON)
+set(USE_CUDNN OFF)
+set(CAFFE2_USE_CUDNN OFF)
 set(USE_CUSPARSELT OFF)
 
 ## Find libTorch installation
 find_package(Torch REQUIRED HINTS ${LIBTORCH_INSTALL_ROOT}/share/cmake/Torch/ QUIET)
+find_package(OpenCV REQUIRED HINTS ${OPENCV_INSTALL_ROOT}/build/ QUIET)
+
+include_directories(
+  ${TORCH_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
+)
 
 ## Build & Link
 add_executable(deploy_libtorch main.cpp)
-target_link_libraries(deploy_libtorch "${TORCH_LIBRARIES}")
+target_link_libraries(deploy_libtorch ${OpenCV_LIBS} ${TORCH_LIBRARIES} opencv_imgcodecs)

--- a/Models/exports/libtorch/README.md
+++ b/Models/exports/libtorch/README.md
@@ -32,7 +32,7 @@ Run Network:
 ./deploy_libtorch <_input_network_file.pt_> <_input_image_file.png_>
 ```
 
-If this run's successfully it will produce two output files:
+If the application runs successfully it will produce two output files:
 
 1) Segmentation mask image file.
 2) Output image file consisting of segmentation mask overlayed onto the input image.

--- a/Models/exports/libtorch/README.md
+++ b/Models/exports/libtorch/README.md
@@ -1,0 +1,14 @@
+# deploy_libtorch
+Use libTorch to load model and deploy.
+
+## Build Instructions
+export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}
+export LD_LIBRARY_PATH=/usr/local/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+mkdir build && cd build
+
+cmake -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> ..
+
+make
+
+./deploy_libtorch <_*.pt_file_> 

--- a/Models/exports/libtorch/README.md
+++ b/Models/exports/libtorch/README.md
@@ -7,8 +7,8 @@ export LD_LIBRARY_PATH=/usr/local/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRAR
 
 mkdir build && cd build
 
-cmake -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> ..
+cmake -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> -DOPENCV_INSTALL_ROOT=<_opencv_root_location_> ..
 
 make
 
-./deploy_libtorch <_*.pt_file_> 
+./deploy_libtorch <_input_network_file.pt_file_> <_input_image_file.png>

--- a/Models/exports/libtorch/README.md
+++ b/Models/exports/libtorch/README.md
@@ -3,6 +3,7 @@ Use libTorch to load model and deploy.
 
 ## Build Instructions
 export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}
+
 export LD_LIBRARY_PATH=/usr/local/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
 mkdir build && cd build
@@ -11,4 +12,4 @@ cmake -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> -DOPENCV_INSTALL_ROOT=<
 
 make
 
-./deploy_libtorch <_input_network_file.pt_file_> <_input_image_file.png>
+./deploy_libtorch <_input_network_file.pt_> <_input_image_file.png_>

--- a/Models/exports/libtorch/README.md
+++ b/Models/exports/libtorch/README.md
@@ -1,15 +1,38 @@
 # deploy_libtorch
-Use libTorch to load model and deploy.
+This application uses libTorch C++ to load model and inference.
 
 ## Build Instructions
+Set up environment (if using CUDA):
+
+```
 export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}
-
 export LD_LIBRARY_PATH=/usr/local/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+```
 
+Create build location:
+```
 mkdir build && cd build
+```
 
+Configure project:
+
+```
 cmake -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> -DOPENCV_INSTALL_ROOT=<_opencv_root_location_> ..
+```
 
+Build the project:
+
+```
 make
+```
 
+Run Network:
+
+```
 ./deploy_libtorch <_input_network_file.pt_> <_input_image_file.png_>
+```
+
+If this run's successfully it will produce two output files:
+
+1) Segmentation mask image file.
+2) Output image file consisting of segmentation mask overlayed onto the input image.

--- a/Models/exports/libtorch/main.cpp
+++ b/Models/exports/libtorch/main.cpp
@@ -1,7 +1,7 @@
 /*
 **
 FILE:   main.cpp
-DESC:   libTorch network input and oneDNN deployment example
+DESC:   libTorch implementation of exported SceneSeg Network
 **
 */
 
@@ -12,6 +12,14 @@ DESC:   libTorch network input and oneDNN deployment example
 #include <torch/torch.h>
 #include <torch/cuda.h>
 
+#include <opencv2/core.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/highgui.hpp>
+#include<opencv2/imgproc/imgproc.hpp>
+
+using namespace cv; 
+using namespace std; 
+
 /*
 **
 FUNC:   main()
@@ -21,8 +29,8 @@ DESC:   example program entry point
 int main(int argc, char **argv) 
 {
     // Get exported script module
-    if (argc != 2) {
-        std::cerr << "usage: example-app <path-to-exported-script-module>\n";
+    if (argc != 3) {
+        std::cerr << "usage: deploy_libtorch <path-to-exported-script-module>\n";
         return -1;
     }
 
@@ -32,18 +40,119 @@ int main(int argc, char **argv)
     // Try to load the script module
     try {
         // Deserialize the ScriptModule from a file using torch::jit::load().
-        module_ = torch::jit::load(argv[1]);
+        module_ = torch::jit::load(argv[1], torch::kCUDA);
     }
     catch (const c10::Error& e) {
         std::cerr << "ERROR: Failed to load the model." << std::endl;
         return -1;
     }
 
-    std::cerr << "INFO: Model <" << argv[1] << "> loaded successfully." << std::endl;
+    //
+    std::cout << "INFO: Model <" << argv[1] << "> loaded successfully." << std::endl;
+    //
 
-    // Dump the module to output to check
-    std::cout << module_.dump_to_str(true, false, false) << std::endl;
-  
+    // Load an input image
+    cv::Mat frame = cv::imread(argv[2], cv::IMREAD_COLOR); 
+    cv::Mat preImg;
+    cvtColor(frame, preImg, cv::COLOR_BGR2RGB);
+
+    // Resize
+    cv::Mat img;
+    resize(preImg, img, Size(640, 320));    // Fixed ratio from original implementation
+
+    // Convert input cv image to Tensor
+    at::Tensor tensor_image = torch::from_blob(img.data, { img.rows, img.cols, 3 }, at::kByte);
+
+    // Convert to float and scale it 
+    tensor_image = tensor_image.toType(c10::kFloat).div(255);
+
+    // Transpose the image
+    tensor_image = tensor_image.permute({ (2),(0),(1) });
+
+    // Create a batch dimension for input
+    tensor_image.unsqueeze_(0);
+
+    // Normalise the input values
+    std::vector<double> norm_mean = {0.485, 0.456, 0.406};
+    std::vector<double> norm_std = {0.229, 0.224, 0.225};
+    tensor_image = torch::data::transforms::Normalize<>(norm_mean, norm_std)(tensor_image);
+
+    // Create to "input values"
+    auto input_to_net = std::vector<torch::jit::IValue>{tensor_image.to(at::kCUDA)};
+
+    // Push the image through the network forward compute path
+    at::Tensor prediction = module_.forward(input_to_net).toTensor();
+
+    //
+    std::cout << "INFO: Forward compute path executed succssfully." << std::endl;
+    //
+
+    // Post-process the output tensor
+    prediction = prediction.squeeze(0).to(at::kCPU).detach();
+
+    // Transpose back
+    c10::IntArrayRef dims = {1, 2, 0};
+    prediction = prediction.permute(dims);
+
+    // Take max values across 2 dimensions
+    auto final_output = std::get<1>(max(prediction,2,false));
+
+    // Create an image to hold the segmentation mask
+    cv::Mat vis_predict_object(img.rows, img.cols, CV_8UC3, Scalar(0, 0, 0));
+
+    // Process the tensor output and crate output segmentation mask
+    for (int x=0;x<img.rows;x++) // rows
+    {
+        for (int y=0;y<img.cols;y++) // cols
+        {
+            int value = final_output[x][y].item<int>();
+            
+            if (value==0) 
+            {
+                // Background colour
+                vis_predict_object.at<cv::Vec3b>(x,y)=cv::Vec3b(255,93,61);
+            }
+            if (value==1)
+            {
+                // Foreground colour
+                vis_predict_object.at<cv::Vec3b>(x,y)=cv::Vec3b(145,28,255);
+            }
+            if (value==2)
+            {
+                // Background colour
+                vis_predict_object.at<cv::Vec3b>(x,y)=cv::Vec3b(255,93,61);
+            }
+        }
+    }
+
+    //
+    std::cout << "INFO: Segmentation mask created succssfully." << std::endl;
+    //
+
+    // Write out the segmentation mask to file
+    cv::imwrite("output_seg_mask.jpg", vis_predict_object);
+
+    // Transparency factor
+    auto alpha = 0.5;
+
+    // Create an image to hold the segmentation mask
+    cv::Mat final_output_image(frame.rows, frame.cols, CV_8UC3, Scalar(0, 0, 0));
+
+    // Resize
+    cv::Mat out_img;
+    resize(vis_predict_object, out_img, Size(frame.cols, frame.rows));    // Fixed ratio from original implementation
+
+    // Alpha Blend of Segmentation mask onto original input image
+    addWeighted( out_img, alpha, frame, 1-alpha, 0.0, final_output_image);
+
+    //
+    std::cout << "INFO: Output imag created succssfully." << std::endl;
+    //
+
+    // Write out the segmentation mask to file
+    cv::imwrite("output_image.jpg", final_output_image);
+
+    // Done
     return 0;
 }
 /*

--- a/Models/exports/libtorch/main.cpp
+++ b/Models/exports/libtorch/main.cpp
@@ -1,0 +1,53 @@
+/*
+**
+FILE:   main.cpp
+DESC:   libTorch network input and oneDNN deployment example
+**
+*/
+
+#include <assert.h>
+#include <iostream>
+
+#include <torch/script.h>
+#include <torch/torch.h>
+#include <torch/cuda.h>
+
+/*
+**
+FUNC:   main()
+DESC:   example program entry point
+**
+*/
+int main(int argc, char **argv) 
+{
+    // Get exported script module
+    if (argc != 2) {
+        std::cerr << "usage: example-app <path-to-exported-script-module>\n";
+        return -1;
+    }
+
+    // Create a module object to hold the network
+    torch::jit::script::Module module_;
+    
+    // Try to load the script module
+    try {
+        // Deserialize the ScriptModule from a file using torch::jit::load().
+        module_ = torch::jit::load(argv[1]);
+    }
+    catch (const c10::Error& e) {
+        std::cerr << "ERROR: Failed to load the model." << std::endl;
+        return -1;
+    }
+
+    std::cerr << "INFO: Model <" << argv[1] << "> loaded successfully." << std::endl;
+
+    // Dump the module to output to check
+    std::cout << module_.dump_to_str(true, false, false) << std::endl;
+  
+    return 0;
+}
+/*
+**
+End of File
+**
+*/

--- a/Models/exports/onnx_rt/CMakeLists.txt
+++ b/Models/exports/onnx_rt/CMakeLists.txt
@@ -35,12 +35,12 @@ endif()
 # We added the path for the pre-built package above. Add the path for a local install to support either usage.
 # TODO: If we want to support additional EPs being loadable from a local install we also need to add EP specific
 # directories under /include/onnxruntime/core/providers
-include_directories("${ONNXRUNTIME_ROOTDIR}/include"                                    # Pre-built package
-                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime"                        # Linux local install to /usr/local
-                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime/core/session"           # Windows local install
+include_directories("${ONNXRUNTIME_ROOTDIR}/include"
+                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime"
+                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime/core/session"
                     "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime/core/providers/dnnl"    # DNNL Backend Support
                     ${OpenCV_INCLUDE_DIRS}                                              # OpenCV
-                    ${TORCH_INCLUDE_DIRS})
+                    ${TORCH_INCLUDE_DIRS})                                              # Torch
 
 link_directories("${ONNXRUNTIME_ROOTDIR}/lib")
 

--- a/Models/exports/onnx_rt/CMakeLists.txt
+++ b/Models/exports/onnx_rt/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+project(deploy_onnx_rt)
+
+set(USE_CUDNN OFF)
+set(CAFFE2_USE_CUDNN OFF)
+set(USE_CUSPARSELT OFF)
+
+## Find OpenCV installation
+find_package(OpenCV REQUIRED HINTS ${OPENCV_INSTALL_ROOT}/build/ QUIET)
+find_package(Torch REQUIRED HINTS ${LIBTORCH_INSTALL_ROOT}/share/cmake/Torch/ QUIET)
+
+string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra")
+string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
+
+## ONNX Runtime Providers
+option(onnxruntime_USE_CUDA "Build with CUDA support" OFF)
+option(onnxruntime_USE_TENSORRT "Build with TensorRT support" OFF)
+option(LIBPNG_ROOTDIR "libpng root dir")
+option(ONNXRUNTIME_ROOTDIR "onnxruntime root dir")
+set(CMAKE_CXX_STANDARD 17)
+
+if(NOT ONNXRUNTIME_ROOTDIR)
+    message(STATUS "You must provide an onnx runtime root directory!")
+endif()
+
+# The ORT package has a different include directory structure to a local install via cmake.
+# We added the path for the pre-built package above. Add the path for a local install to support either usage.
+# TODO: If we want to support additional EPs being loadable from a local install we also need to add EP specific
+# directories under /include/onnxruntime/core/providers
+include_directories("${ONNXRUNTIME_ROOTDIR}/include"                            # Pre-built package
+                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime"                # Linux local install to /usr/local
+                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime/core/session"   # Windows local install
+                    ${OpenCV_INCLUDE_DIRS}                                      # OpenCV
+                    ${TORCH_INCLUDE_DIRS})
+
+link_directories("${ONNXRUNTIME_ROOTDIR}/lib")
+
+if(onnxruntime_USE_CUDA)
+    add_definitions(-DUSE_CUDA)
+endif()
+
+## Build & Link
+add_executable(deploy_onnx_rt main.cpp)
+target_link_libraries(deploy_onnx_rt PRIVATE onnxruntime ${TORCH_LIBRARIES} ${OpenCV_LIBS} opencv_imgcodecs)

--- a/Models/exports/onnx_rt/CMakeLists.txt
+++ b/Models/exports/onnx_rt/CMakeLists.txt
@@ -5,6 +5,14 @@ set(USE_CUDNN OFF)
 set(CAFFE2_USE_CUDNN OFF)
 set(USE_CUSPARSELT OFF)
 
+if(USE_CUDA_BACKEND)
+    add_definitions(-DUSE_EP_CUDA)
+    message(STATUS "Using CUDA Execution Provider Backend")
+elseif(USE_DNNL_BACKEND)
+    add_definitions(-DUSE_EP_DNNL)
+    message(STATUS "Using DNNL Execution Provider Backend")
+endif()
+
 ## Find OpenCV installation
 find_package(OpenCV REQUIRED HINTS ${OPENCV_INSTALL_ROOT}/build/ QUIET)
 find_package(Torch REQUIRED HINTS ${LIBTORCH_INSTALL_ROOT}/share/cmake/Torch/ QUIET)
@@ -27,10 +35,11 @@ endif()
 # We added the path for the pre-built package above. Add the path for a local install to support either usage.
 # TODO: If we want to support additional EPs being loadable from a local install we also need to add EP specific
 # directories under /include/onnxruntime/core/providers
-include_directories("${ONNXRUNTIME_ROOTDIR}/include"                            # Pre-built package
-                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime"                # Linux local install to /usr/local
-                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime/core/session"   # Windows local install
-                    ${OpenCV_INCLUDE_DIRS}                                      # OpenCV
+include_directories("${ONNXRUNTIME_ROOTDIR}/include"                                    # Pre-built package
+                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime"                        # Linux local install to /usr/local
+                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime/core/session"           # Windows local install
+                    "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime/core/providers/dnnl"    # DNNL Backend Support
+                    ${OpenCV_INCLUDE_DIRS}                                              # OpenCV
                     ${TORCH_INCLUDE_DIRS})
 
 link_directories("${ONNXRUNTIME_ROOTDIR}/lib")

--- a/Models/exports/onnx_rt/README.md
+++ b/Models/exports/onnx_rt/README.md
@@ -1,0 +1,15 @@
+# deploy_libtorch
+Use ONNX Runtime to load model and deploy.
+
+## Build Instructions
+export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}
+
+export LD_LIBRARY_PATH=/usr/local/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+mkdir build && cd build
+
+cmake -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> -DOPENCV_INSTALL_ROOT=<_opencv_root_location_> -DONNXRUNTIME_ROOTDIR=<_onnx_runtime_root_location_> ..
+
+make
+
+./deploy_onnx_rt <_input_network_file.onnx_> <_input_image_file.png_>

--- a/Models/exports/onnx_rt/README.md
+++ b/Models/exports/onnx_rt/README.md
@@ -1,8 +1,11 @@
 # deploy_onnx_rt
-Use ONNX Runtime to load model and deploy.
+This application uses ONNX Runtime to load model and inference on the following ONNX Runtime Execution Providers:
+
+1) CUDA
+2) DNNL (oneDNN)
 
 ## Build Instructions
-Set up environment:
+Set up environment (if using CUDA):
 
 ```
 export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}

--- a/Models/exports/onnx_rt/README.md
+++ b/Models/exports/onnx_rt/README.md
@@ -1,4 +1,4 @@
-# deploy_libtorch
+# deploy_onnx_rt
 Use ONNX Runtime to load model and deploy.
 
 ## Build Instructions

--- a/Models/exports/onnx_rt/README.md
+++ b/Models/exports/onnx_rt/README.md
@@ -8,6 +8,7 @@ Set up environment:
 export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}
 
 export LD_LIBRARY_PATH=/usr/local/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+```
 
 Create build location:
 
@@ -46,6 +47,7 @@ make
 ```
 
 Run Network:
+
 ```
 ./deploy_onnx_rt <_input_network_file.onnx_> <_input_image_file.png_>
 ```

--- a/Models/exports/onnx_rt/README.md
+++ b/Models/exports/onnx_rt/README.md
@@ -9,7 +9,6 @@ Set up environment (if using CUDA):
 
 ```
 export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}
-
 export LD_LIBRARY_PATH=/usr/local/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 ```
 

--- a/Models/exports/onnx_rt/README.md
+++ b/Models/exports/onnx_rt/README.md
@@ -2,16 +2,21 @@
 Use ONNX Runtime to load model and deploy.
 
 ## Build Instructions
+Set up environment:
+
 ```
 export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}
 
 export LD_LIBRARY_PATH=/usr/local/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
+Create build location:
+
+```
 mkdir build && cd build
 
 ```
 
-To build with CUDA Execution Provider:
+To configure project with CUDA Execution Provider (EP):
 
 ```
 
@@ -23,7 +28,7 @@ cmake   -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_>
 
 ```
 
-To build with DNNL Execution Provider:
+To configure project with DNNL Execution Provider (EP):
 
 ```
 cmake   -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> 
@@ -32,7 +37,20 @@ cmake   -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_>
         -DUSE_DNNL_BACKEND=True
         ..
 
-make
+```
 
+Build Project:
+
+```
+make
+```
+
+Run Network:
+```
 ./deploy_onnx_rt <_input_network_file.onnx_> <_input_image_file.png_>
 ```
+
+If this run's successfully it will produce two output files:
+
+1) Segmentation mask image file.
+2) Output image file consisting of segmentation mask overlayed onto the input image.

--- a/Models/exports/onnx_rt/README.md
+++ b/Models/exports/onnx_rt/README.md
@@ -54,7 +54,7 @@ Run Network:
 ./deploy_onnx_rt <_input_network_file.onnx_> <_input_image_file.png_>
 ```
 
-If this run's successfully it will produce two output files:
+If the application runs successfully it will produce two output files:
 
-1) Segmentation mask image file.
+1) Output segmentation mask image file.
 2) Output image file consisting of segmentation mask overlayed onto the input image.

--- a/Models/exports/onnx_rt/README.md
+++ b/Models/exports/onnx_rt/README.md
@@ -2,14 +2,35 @@
 Use ONNX Runtime to load model and deploy.
 
 ## Build Instructions
+```
 export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}
 
 export LD_LIBRARY_PATH=/usr/local/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
 mkdir build && cd build
 
-cmake -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> -DOPENCV_INSTALL_ROOT=<_opencv_root_location_> -DONNXRUNTIME_ROOTDIR=<_onnx_runtime_root_location_> ..
+```
+
+To build with CUDA Execution Provider:
+
+```
+
+cmake   -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> 
+        -DOPENCV_INSTALL_ROOT=<_opencv_root_location_> 
+        -DONNXRUNTIME_ROOTDIR=<_onnx_runtime_root_location_>
+        -DUSE_CUDA_BACKEND=True
+        ..
+
+To build with DNNL Execution Provider:
+
+```
+cmake   -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_> 
+        -DOPENCV_INSTALL_ROOT=<_opencv_root_location_> 
+        -DONNXRUNTIME_ROOTDIR=<_onnx_runtime_root_location_>
+        -DUSE_DNNL_BACKEND=True
+        ..
 
 make
 
 ./deploy_onnx_rt <_input_network_file.onnx_> <_input_image_file.png_>
+```

--- a/Models/exports/onnx_rt/README.md
+++ b/Models/exports/onnx_rt/README.md
@@ -21,6 +21,8 @@ cmake   -DLIBTORCH_INSTALL_ROOT=<_libTorch_root_location_>
         -DUSE_CUDA_BACKEND=True
         ..
 
+```
+
 To build with DNNL Execution Provider:
 
 ```

--- a/Models/exports/onnx_rt/main.cpp
+++ b/Models/exports/onnx_rt/main.cpp
@@ -193,7 +193,7 @@ int main(int argc, ORTCHAR_T* argv[])
     }
 
     // Input and Output Processing
-	std::vector<const char*> inputNodeNames;
+    std::vector<const char*> inputNodeNames;
 	std::vector<const char*> outputNodeNames;
 	std::vector<int64_t> inputTensorShape;
 	std::vector<int64_t> outputTensorShape;

--- a/Models/exports/onnx_rt/main.cpp
+++ b/Models/exports/onnx_rt/main.cpp
@@ -1,0 +1,359 @@
+/*
+**
+FILE:   main.cpp
+DESC:   C++ Deployment of SceneSeg Network
+**
+*/
+
+#include <algorithm>  // std::generate
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <torch/script.h>
+#include <torch/torch.h>
+#include <torch/cuda.h>
+
+#include <onnxruntime_cxx_api.h>
+
+#include <opencv2/core.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/dnn.hpp>
+
+using namespace cv; 
+using namespace std; 
+
+/*
+**
+FUNC:   print_tensor_shape
+DESC:   Prints shape of tensor
+**
+*/
+std::string print_tensor_shape(const std::vector<std::int64_t>& vTensorShape) 
+{
+    std::stringstream stream("");
+
+    for (unsigned int i = 0; i < vTensorShape.size() - 1; i++) 
+    {
+        stream << vTensorShape[i] << "x";
+    }
+
+    stream << vTensorShape[vTensorShape.size() - 1];
+    
+    return stream.str();
+}
+
+/*
+**
+FUNC:   main()
+DESC:   Example program entry point
+**
+*/
+
+int main(int argc, ORTCHAR_T* argv[]) 
+{
+    std::cout << std::endl << "\033[1;33m" << "==> Program Start:" << "\033[0m\n"  << std::endl;
+
+    if (argc != 3) {
+        std::cerr << "Usage: ./deploy_onnx_rt <onnx_model.onnx> <test_image.png>" << std::endl;
+        return -1;
+    }
+
+    /*
+    ************************************************************
+    * ONNX RT to load and query the netowrk
+    ************************************************************
+    */
+
+    // Save model file name
+    std::basic_string<ORTCHAR_T> model_file = argv[1];
+
+    // Check available execution platforms
+    auto providers = Ort::GetAvailableProviders();
+    std::cout << "INFO: Execution providers in this system:" << std::endl;
+    
+    for (auto provider : providers) {
+        std::cout << "      - " << provider << std::endl;
+    }
+    std::cout << endl;
+
+    // Create ORT Environment
+    Ort::Env env = Ort::Env(OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING, "Default");
+
+    // Structures for options
+    Ort::SessionOptions session_options;
+    OrtCUDAProviderOptions cuda_options;
+
+    // Single CPU thread only
+    session_options.SetInterOpNumThreads(1);
+    session_options.SetIntraOpNumThreads(1);
+
+    // Optimization will take time and memory during startup
+    session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_DISABLE_ALL);
+
+    // Use CUDA
+    if (true /* Use Cuda */)
+    {
+        cuda_options.device_id = 0;
+        cuda_options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearchExhaustive; // Algo to search for Cudnn
+        cuda_options.arena_extend_strategy = 0;
+
+        // May cause data race in some condition
+        cuda_options.do_copy_in_default_stream = 0;
+        session_options.AppendExecutionProvider_CUDA(cuda_options); // Add CUDA options to session options
+    }
+
+    // Create ONNX Session
+    Ort::Session session = Ort::Session(env, model_file.c_str(), session_options);
+
+    // Input Shape Information
+    Ort::AllocatorWithDefaultOptions allocator;
+    std::vector<std::string> input_names;
+    std::vector<std::int64_t> input_shapes;
+
+    std::cout << "INFO: Input Nodes (" << input_names.size() << "):" << std::endl;
+
+    for (std::size_t i = 0; i < session.GetInputCount(); i++) 
+    {
+        input_names.emplace_back(session.GetInputNameAllocated(i, allocator).get());
+        input_shapes = session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape();
+        std::cout << "      - " <<  input_names.at(i) << " : " << print_tensor_shape(input_shapes) << std::endl;
+    }
+    std::cout << endl;
+
+    // some models might have negative shape values to indicate dynamic shape, e.g., for variable batch size.
+    for (auto& s : input_shapes) 
+    {
+        if (s < 0) {
+        s = 1;
+        }
+    }
+
+    // Output Shape Information
+    std::vector<std::string> output_names;
+    std::cout << "INFO: Output Nodes (" << output_names.size() << "):" << std::endl;
+
+    for (std::size_t i = 0; i < session.GetOutputCount(); i++) 
+    {
+        output_names.emplace_back(session.GetOutputNameAllocated(i, allocator).get());
+        auto output_shapes = session.GetOutputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape();
+        std::cout << "      - " << output_names.at(i) << " : " << print_tensor_shape(output_shapes) << std::endl;
+    }
+    std::cout << endl;
+
+    // Assume model has 1 input node and 1 output node.
+    assert(input_names.size() == 1 && output_names.size() == 1);
+
+    // Create a single Ort tensor of random numbers
+    auto input_shape = input_shapes;
+
+    // Memory Initialisation - Used to allocate memory for input
+    Ort::MemoryInfo memory_info{ nullptr };     
+
+    try 
+    {
+        memory_info = std::move(Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault));
+    }
+    catch (Ort::Exception &oe) 
+    {
+        std::cout << "INFO: ONNX exception caught: " << oe.what() << ". Code: " << oe.GetOrtErrorCode() << ".\n";
+        return -1;
+    }
+
+    // Input and Output Processing
+	std::vector<const char*> inputNodeNames;
+	std::vector<const char*> outputNodeNames;
+	std::vector<int64_t> inputTensorShape;
+	std::vector<int64_t> outputTensorShape;
+	std::vector<int64_t> outputMaskTensorShape;
+
+	auto temp_input_name0 = session.GetInputNameAllocated(0, allocator);
+	inputNodeNames.push_back(temp_input_name0.get());
+
+	Ort::TypeInfo inputTypeInfo = session.GetInputTypeInfo(0);
+	auto input_tensor_info = inputTypeInfo.GetTensorTypeAndShapeInfo();
+
+	inputTensorShape = input_tensor_info.GetShape();
+
+    std::vector<std::vector<int64_t>> input_node_dims;
+    input_node_dims.push_back(inputTensorShape);
+
+    // Onnx Runtime allowed input
+    std::vector<Ort::Value> input_tensors;       
+
+    /*
+    ************************************************************
+    * libTORCH and OpenCV to load and prepare the input image
+    ************************************************************
+    */
+
+    // Load an input image
+    cv::Mat frame = cv::imread(argv[2], cv::IMREAD_COLOR); 
+    cv::Mat preImg;
+    cvtColor(frame, preImg, cv::COLOR_BGR2RGB);
+
+    // Resize
+    cv::Mat img;
+    resize(preImg, img, Size(640, 320));    // Fixed ratio from original network implementation
+
+    // Convert input cv image to Tensor
+    at::Tensor tensor_image = torch::from_blob(img.data, { img.rows, img.cols, 3 }, at::kByte);
+
+    // Convert to float and scale it 
+    tensor_image = tensor_image.toType(c10::kFloat).div(255);
+
+    // Transpose the image
+    tensor_image = tensor_image.permute({ (2),(0),(1) });
+
+    // Create a batch dimension for input
+    tensor_image.unsqueeze_(0);
+
+    // Normalise the input values
+    std::vector<double> norm_mean = {0.485, 0.456, 0.406};
+    std::vector<double> norm_std = {0.229, 0.224, 0.225};
+    tensor_image = torch::data::transforms::Normalize<>(norm_mean, norm_std)(tensor_image);
+
+    // Need to physically permute the input data from RGBRGBRGB to RRRGGGBBB... etc
+    float fPhysicallyPermutedInputArray[1][3][320][640];
+
+    std::cout << "INFO: Permuting Input Data:" << endl;
+    for (int chan=0;chan<3;chan++)
+    {
+        for (int cols=0;cols<640;cols++)
+        {
+            for (int rows=0;rows<320;rows++)
+            {
+                fPhysicallyPermutedInputArray[0][chan][rows][cols] = tensor_image[0][chan][rows][cols].item<float>();
+            }
+        }
+    }
+    std::cout << "INFO: Done." << endl;
+
+    /*
+    ************************************************************
+    * ONNX RT to run the network
+    ************************************************************
+    */
+ 
+    try 
+    {
+        input_tensors.emplace_back(Ort::Value::CreateTensor<float>(memory_info, (float*)fPhysicallyPermutedInputArray, tensor_image.numel(), input_node_dims[0].data(), input_node_dims[0].size()));
+    }
+    catch (Ort::Exception &oe) 
+    {
+        std::cout << "INFO: ONNX exception caught: " << oe.what() << ". Code: " << oe.GetOrtErrorCode() << ".\n";
+        return -1;
+    }
+
+    // double-check the dimensions of the input tensor
+    assert(input_tensors[0].IsTensor() && input_tensors[0].GetTensorTypeAndShapeInfo().GetShape() == input_shape);
+    std::cout << "INFO: Input_tensor shape: " << endl << "      - " << print_tensor_shape(input_tensors[0].GetTensorTypeAndShapeInfo().GetShape()) << std::endl << std::endl;
+
+    // pass data through model
+    std::vector<const char*> input_names_char(input_names.size(), nullptr);
+    std::transform(std::begin(input_names), std::end(input_names), std::begin(input_names_char),
+                    [&](const std::string& str) { return str.c_str(); });
+
+    std::vector<const char*> output_names_char(output_names.size(), nullptr);
+    std::transform(std::begin(output_names), std::end(output_names), std::begin(output_names_char),
+                    [&](const std::string& str) { return str.c_str(); });
+
+    std::cout << "INFO: Running model:" << std::endl;
+
+    auto output_tensors = session.Run(Ort::RunOptions{nullptr}, input_names_char.data(), input_tensors.data(),
+                                    input_names_char.size(), output_names_char.data(), output_names_char.size());
+
+    std::cout << "INFO: Done." << std::endl;
+
+     // Get pointer to output tensor float values
+    float* floatarr = output_tensors.front().GetTensorMutableData<float>();
+
+    // Copy ONNX Runtime Output Tensor Data to libTorch Tensor
+    at::Tensor prediction = torch::from_blob(floatarr, { 1, 3, img.rows, img.cols}, at::kFloat);
+
+    std::cout << "INFO: Forward compute path executed succssfully." << std::endl;
+
+    /*
+    ************************************************************
+    * libTORCH to post process the output and save
+    ************************************************************
+    */
+
+    // Post-process the output tensor
+    prediction = prediction.squeeze(0).to(at::kCPU).detach();
+
+    // Transpose back
+    c10::IntArrayRef dims = {1, 2, 0};
+    prediction = prediction.permute(dims);
+
+    // Take max values across 2 dimensions
+    auto final_output = std::get<1>(max(prediction,2,false));
+
+    // Create an image to hold the segmentation mask
+    cv::Mat vis_predict_object(img.rows, img.cols, CV_8UC3, Scalar(0, 0, 0));
+
+    // Process the tensor output and crate output segmentation mask
+    for (int x=0;x<img.rows;x++) // rows
+    {
+        for (int y=0;y<img.cols;y++) // cols
+        {
+            int value = final_output[x][y].item<int>();
+            
+            if (value==0) 
+            {
+                // Background colour
+                vis_predict_object.at<cv::Vec3b>(x,y)=cv::Vec3b(255,93,61);
+            }
+            if (value==1)
+            {
+                // Foreground colour
+                vis_predict_object.at<cv::Vec3b>(x,y)=cv::Vec3b(145,28,255);
+            }
+            if (value==2)
+            {
+                // Background colour
+                vis_predict_object.at<cv::Vec3b>(x,y)=cv::Vec3b(255,93,61);
+            }
+        }
+    }
+
+    std::cout << "INFO: Segmentation mask created succssfully." << std::endl;
+
+    // Write out the segmentation mask to file
+    cv::imwrite("output_seg_mask.jpg", vis_predict_object);
+
+    // Transparency factor
+    auto alpha = 0.5;
+
+    // Create an image to hold the segmentation mask
+    cv::Mat final_output_image(frame.rows, frame.cols, CV_8UC3, Scalar(0, 0, 0));
+
+    // Resize
+    cv::Mat out_img;
+    resize(vis_predict_object, out_img, Size(frame.cols, frame.rows));    // Fixed ratio from original implementation
+
+    // Alpha Blend of Segmentation mask onto original input image
+    addWeighted( out_img, alpha, frame, 1-alpha, 0.0, final_output_image);
+
+    std::cout << "INFO: Output image created succssfully." << std::endl;
+
+    // Write out the segmentation mask to file
+    cv::imwrite("output_image.jpg", final_output_image);
+
+    std::cout << endl << "\033[1;33m" << "<== Program End" << "\033[0m\n" << std::endl << std::endl;
+
+    // Done
+    return 0;
+}
+
+/*
+**
+End of File
+**
+*/

--- a/Models/exports/onnx_rt/main.cpp
+++ b/Models/exports/onnx_rt/main.cpp
@@ -194,22 +194,22 @@ int main(int argc, ORTCHAR_T* argv[])
 
     // Input and Output Processing
     std::vector<const char*> inputNodeNames;
-	std::vector<const char*> outputNodeNames;
-	std::vector<int64_t> inputTensorShape;
-	std::vector<int64_t> outputTensorShape;
-	std::vector<int64_t> outputMaskTensorShape;
-
-	auto temp_input_name0 = session.GetInputNameAllocated(0, allocator);
-	inputNodeNames.push_back(temp_input_name0.get());
-
-	Ort::TypeInfo inputTypeInfo = session.GetInputTypeInfo(0);
-	auto input_tensor_info = inputTypeInfo.GetTensorTypeAndShapeInfo();
-
-	inputTensorShape = input_tensor_info.GetShape();
-
+    std::vector<const char*> outputNodeNames;
+    std::vector<int64_t> inputTensorShape;
+    std::vector<int64_t> outputTensorShape;
+    std::vector<int64_t> outputMaskTensorShape;
+    
+    auto temp_input_name0 = session.GetInputNameAllocated(0, allocator);
+    inputNodeNames.push_back(temp_input_name0.get());
+    
+    Ort::TypeInfo inputTypeInfo = session.GetInputTypeInfo(0);
+    auto input_tensor_info = inputTypeInfo.GetTensorTypeAndShapeInfo();
+    
+    inputTensorShape = input_tensor_info.GetShape();
+    
     std::vector<std::vector<int64_t>> input_node_dims;
     input_node_dims.push_back(inputTensorShape);
-
+    
     // Onnx Runtime allowed input
     std::vector<Ort::Value> input_tensors;       
 

--- a/Models/exports/traced_script_module_save.py
+++ b/Models/exports/traced_script_module_save.py
@@ -25,7 +25,8 @@ def main():
     parser = ArgumentParser()
     parser.add_argument("-p", "--model_checkpoint_path", dest="model_checkpoint_path", help="path to pytorch checkpoint file to load model dict")
     parser.add_argument("-i", "--input_image_filepath", dest="input_image_filepath", help="path to input image which will be processed by SceneSeg")
-    parser.add_argument("-o", "--output_trace_filepath", dest="output_trace_filepath", help="path to ouput trace file generated")
+    parser.add_argument("-o1", "--output_pt_trace_filepath", dest="output_pt_trace_filepath", help="path to *.pt output trace file generated")
+    parser.add_argument("-o2", "--output_onnx_trace_filepath", dest="output_onnx_trace_filepath", help="path to *.onnx output trace file generated")
     args = parser.parse_args() 
 
     # Saved model checkpoint path
@@ -69,12 +70,16 @@ def main():
     image_tensor = image_tensor.unsqueeze(0)
     image_tensor = image_tensor.to(device)
 
+    # Torch Export
     # Run and Trace the model with input image
     traced_script_module = torch.jit.trace(model, image_tensor)
-    traced_script_module.save(args.output_trace_filepath) 
+    traced_script_module.save(args.output_pt_trace_filepath) 
+    print("INFO: Torch Trace Export file generated successfully.")
 
-    print("INFO: Trace file generated successfully.")
-
+    # ONNX export
+    onnx_program = torch.onnx.dynamo_export(model, image_tensor)
+    onnx_program.save(args.output_onnx_trace_filepath)
+    print("INFO: ONNX Export file generated successfully.")
 
 if __name__ == '__main__':
     main()

--- a/Models/exports/traced_script_module_save.py
+++ b/Models/exports/traced_script_module_save.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+import torch
+import torchvision
+from torch.export import export
+from torchvision import transforms
+
+import cv2
+import sys
+import numpy as np
+from PIL import Image
+from argparse import ArgumentParser
+
+sys.path.append('..')
+
+from inference.scene_seg_infer import SceneSegNetworkInfer
+from model_components.scene_seg_network import SceneSegNetwork
+
+##
+## Example Usage: "python3 traced_script_module_save.py -p _checkpoint_file_.pth -i _test_image_.png -o _output_trace_file.pt"
+##
+
+def main(): 
+
+    # Command line arguments
+    parser = ArgumentParser()
+    parser.add_argument("-p", "--model_checkpoint_path", dest="model_checkpoint_path", help="path to pytorch checkpoint file to load model dict")
+    parser.add_argument("-i", "--input_image_filepath", dest="input_image_filepath", help="path to input image which will be processed by SceneSeg")
+    parser.add_argument("-o", "--output_trace_filepath", dest="output_trace_filepath", help="path to ouput trace file generated")
+    args = parser.parse_args() 
+
+    # Saved model checkpoint path
+    model_checkpoint_path = args.model_checkpoint_path
+
+    # Checking devices (GPU vs CPU)
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f'INFO: Using {device} for inference.')
+        
+    # Instantiate model, load to device and set to evaluation mode
+    model = SceneSegNetwork()
+
+    # Load the model weights etc.
+    if(len(model_checkpoint_path) > 0):
+        model.load_state_dict(torch.load \
+            (model_checkpoint_path, weights_only=True, map_location=device))
+    else:
+        raise ValueError('ERROR: No path to checkpiont file provided in class initialization.')
+    
+    # Check the initialisation
+    model = model.to(device)
+    model = model.eval()
+
+    # Image loader Helper
+    image_loader = transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+        ]
+    )
+
+    # Reading input image
+    input_image_filepath = args.input_image_filepath
+    frame = cv2.imread(input_image_filepath, cv2.IMREAD_COLOR)
+    image = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+    image_pil = Image.fromarray(image)
+    image_pil = image_pil.resize((640, 320))
+
+    # Prepare input image
+    image_tensor = image_loader(image_pil)
+    image_tensor = image_tensor.unsqueeze(0)
+    image_tensor = image_tensor.to(device)
+
+    # Run and Trace the model with input image
+    traced_script_module = torch.jit.trace(model, image_tensor)
+    traced_script_module.save(args.output_trace_filepath) 
+
+    print("INFO: Trace file generated successfully.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request adds the following:

- ./Models/export/ – Python script to export your network as torch script and onnx runtime files
- ./Models/export/libTorch – Application to load torch script file and inference network
- ./Models/export/onnx_rt – Application to load torch script file and inference network using either CUDA or DNNL (oneDNN) execution provider backends.
