### PR TITLE
[EgoPath] Data Loader

### DIFF
--- a/Models/data_utils/README.md
+++ b/Models/data_utils/README.md
@@ -9,5 +9,36 @@ Script to perform a sanity check on data for processing, ensuring that data is r
 ## load_data_scene_seg.py
 Helper class for the [SceneSeg Neural network](https://github.com/autowarefoundation/autoware.privately-owned-vehicles/tree/main/SceneSeg) to load multiple datasets, separate data into training and validation splits and extract a Region of Interest (ROI) from images
 
+## load_data_ego_path.py
+
+Helper class for the [EgoPath detection network](https://github.com/autowarefoundation/autoware.privately-owned-vehicles/tree/main/EgoPath) to load multiple datasets, separate data into training and validation splits, before feeding them into the network training.
+
+Please note that in order for `LoadDataEgoPath` class to work properly, the label JSON file must be in the structure of:
+
+```json
+{
+  <frame_code_1>: {
+    "drivable_path": [
+      [<x_1>, <y_1>],
+      [<x_2>, <y_2>],
+      [<x_3>, <y_3>],
+      .............
+      [<x_n>, <y_n>],
+    ],
+    .................
+  },
+  <frame_code_2>: {
+    "drivable_path": [
+      [<x_1>, <y_1>],
+      [<x_2>, <y_2>],
+      [<x_3>, <y_3>],
+      .............
+      [<x_n>, <y_n>],
+    ],
+    .................
+  },
+  ...................
+```
+
 ## benchmark.py
 Script to print model layers, number of parameters, and measure inference speed of model at either FP32 or FP16 precision

--- a/Models/data_utils/load_data_ego_path.py
+++ b/Models/data_utils/load_data_ego_path.py
@@ -12,15 +12,15 @@ from check_data import CheckData
 VALID_DATASET_LITERALS = Literal[
     "BDD100K", 
     "COMMA2K19", 
-    # "CULANE", 
+    "CULANE", 
     "CURVELANES", 
     "ROADWORK", 
     "TUSIMPLE"
 ]
 VALID_DATASET_LIST = list(get_args(VALID_DATASET_LITERALS))
-COMMA2K19_SIZE = {
-    "w" : 1048,
-    "h" : 524
+COMMA2K19_DIMS = {
+    "WIDTH" : 1048,
+    "HEIGHT" : 524
 }
 
 
@@ -93,12 +93,12 @@ class LoadDataEgoPath():
                     if (self.dataset_name == "COMMA2K19"):
                         self.labels[frame_id]["drivable_path"] = [
                             (
-                                point[0] / COMMA2K19_SIZE["w"], 
-                                point[1] / COMMA2K19_SIZE["h"]
+                                point[0] / COMMA2K19_DIMS["WIDTH"], 
+                                point[1] / COMMA2K19_DIMS["HEIGHT"]
                             ) for point in self.labels[frame_id]["drivable_path"]
                         ]
 
-                    if (set_idx % 10 == 0):
+                    if (set_idx % 10 == 0):     # Hard-coded 10% as val set
                         # Slap it to Val
                         self.val_images.append(str(self.images[set_idx]))
                         self.val_labels.append(self.labels[frame_id])
@@ -184,45 +184,3 @@ class LoadDataEgoPath():
             img.save(os.path.join(vis_output_dir, frame_name))
 
         print(f"Sampling all done, saved at {vis_output_dir}")
-
-
-if __name__ == "__main__":
-    # Testing cases here, running through all 6 datasets
-    # Feel free to change dir configs as per yours
-    # Below setting applies for this structure, which is by default:
-    
-    # |---- <datasets_repo>/
-    # |     |------ <dataset_name in UPPERCASE>/
-    # |     |       |------ image/
-    # |     |       |------ segmentation/
-    # |     |       |------ visualization/
-    # |     |       |------ drivable_path.json
-
-    datasets_repo = "/home/tranhuunhathuy/Documents/Autoware/pov_datasets/"
-
-    for dataset_name in VALID_DATASET_LIST:
-
-        print(f"\n{dataset_name}\n")
-
-        TestDataset = LoadDataEgoPath(
-            labels_filepath = os.path.join(
-                datasets_repo, 
-                f"processed_{dataset_name}", 
-                "drivable_path.json"
-            ),
-            images_filepath = os.path.join(
-                datasets_repo, 
-                f"processed_{dataset_name}", 
-                "image"
-            ),
-            dataset = dataset_name,
-        )
-
-        TestDataset.sampleItemsAudit(
-            "train",
-            os.path.join(
-                datasets_repo, 
-                f"processed_{dataset_name}", 
-                "dataloader_sample"
-            )
-        )

--- a/Models/data_utils/load_data_ego_path.py
+++ b/Models/data_utils/load_data_ego_path.py
@@ -2,6 +2,9 @@
 
 import json
 import pathlib
+import numpy as np
+from pprint import pprint
+from PIL import Image
 from typing import Literal, get_args
 from check_data import CheckData
 
@@ -82,16 +85,41 @@ class LoadDataEgoPath():
         print(f"Dataset {self.dataset_name} loaded with {self.N_trains} trains and {self.N_vals} vals.")
         print(f"Val/Total = {(self.N_vals / (self.N_trains + self.N_vals)):.4f}")
 
+    # Get sizes of Train/Val sets
     def getItemCount(self):
         return self.N_trains, self.N_vals
+
+    # ================= Get item at index ith, returning img and EgoPath ================= #
     
+    # For train
+    def getItemTrain(self, index):
+        print(str(self.train_images[index]))
+        img_train = Image.open(str(self.train_images[index])).convert("RGB")
+        label_train = self.train_labels[index]["drivable_path"]
+        
+        img_train = np.expand_dims(img_train, axis = -1)
+        return  np.array(img_train), label_train
+    
+    # For val
+    def getItemVal(self, index):
+        img_val = Image.open(str(self.val_images[index])).convert("RGB")
+        label_val = self.val_labels[index]["drivable_path"]
+        
+        img_val = np.expand_dims(img_val, axis = -1)
+        return  np.array(img_val), label_val
+
 
 if __name__ == "__main__":
-    # Better write some unit tests to check this module
     # Testing cases here
-    TuSimpleDataset = LoadDataEgoPath(
+    CULaneDataset = LoadDataEgoPath(
         labels_filepath = "/home/tranhuunhathuy/Documents/Autoware/pov_datasets/processed_CULane/drivable_path.json",
         images_filepath = "/home/tranhuunhathuy/Documents/Autoware/pov_datasets/processed_CULane/image",
         dataset = "CULANE",
         val_set_fraction = 0.1
     )
+    print("Item count: ")
+    pprint(CULaneDataset.getItemCount())
+    print("Get first train item: ")
+    pprint(CULaneDataset.getItemTrain(0))
+    print("Get first val item: ")
+    pprint(CULaneDataset.getItemVal(0))

--- a/Models/data_utils/load_data_ego_path.py
+++ b/Models/data_utils/load_data_ego_path.py
@@ -108,6 +108,8 @@ class LoadDataEgoPath():
     def getItemTrain(self, index):
         img_train = Image.open(str(self.train_images[index])).convert("RGB")
         label_train = self.train_labels[index]["drivable_path"]
+        # Address the issue currently occurs in CurveLanes
+        label_train = [[x, y] for [x, y] in label_train if y < 1.0]
         
         return np.array(img_train), label_train
     
@@ -115,6 +117,8 @@ class LoadDataEgoPath():
     def getItemVal(self, index):
         img_val = Image.open(str(self.val_images[index])).convert("RGB")
         label_val = self.val_labels[index]["drivable_path"]
+        # Address the issue currently occurs in CurveLanes
+        label_val = [[x, y] for [x, y] in label_val if y < 1.0]
         
         return np.array(img_val), label_val
     
@@ -153,7 +157,7 @@ class LoadDataEgoPath():
 
             # Renormalize
             ego_path = [
-                (point[0] * img_width, point[1] * img_height) 
+                (float(point[0] * img_width), float(point[1] * img_height)) 
                 for point in ego_path
             ]
 

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -94,3 +94,14 @@ class LoadDataEgoPath():
 
     def getItemCount(self):
         return self.num_train_samples, self.num_val_samples
+    
+
+if __name__ == "__main__":
+    # Better write some unit tests to check this module
+    # Testing cases here
+    TuSimpleDataset = LoadDataEgoPath(
+        labels_filepath = "/home/tranhuunhathuy/Documents/Autoware/pov_datasets/processed_CULane/drivable_path.json",
+        images_filepath = "/home/tranhuunhathuy/Documents/Autoware/pov_datasets/processed_CULane/image",
+        dataset = "CULANE",
+        val_set_fraction = 0.1
+    )

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -30,7 +30,6 @@ class LoadDataEgoPath():
             images_filepath: str,
             dataset: VALID_DATASET_LITERALS,
             val_set_fraction: float = 0.1,
-            random_seed = 0
     ):
         
         # ================= Parsing param ================= #
@@ -39,7 +38,6 @@ class LoadDataEgoPath():
         self.image_dirpath = images_filepath
         self.dataset_name = dataset
         self.val_set_fraction = val_set_fraction
-        self.random_seed = random_seed
 
         # ================= Preliminary checks ================= #
 
@@ -57,3 +55,12 @@ class LoadDataEgoPath():
 
         self.N_labels = len(self.label_list)
         self.N_images = len(self.image_list)
+
+        if (self.N_labels != self.N_images):
+            raise ValueError(f"Number of images ({self.N_images}) does not match number of labels ({self.N_labels})")
+        
+        if (self.N_labels == 0):
+            raise ValueError(f"No labels found in specified path {self.label_filepath}")
+        
+        if (self.N_images == 0):
+            raise ValueError(f"No images found in specified path {self.image_dirpath}")

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -70,28 +70,27 @@ class LoadDataEgoPath():
         self.val_images = []
         self.val_labels = []
 
-        self.num_train_samples = 0
-        self.num_val_samples = 0
+        self.N_trains = 0
+        self.N_vals = 0
 
-        if (self.random_seed):
-            random.seed(self.random_seed)
+        if (checkData.getCheck()):
+            for set_idx, label_content in enumerate(self.labels):
+                if (set_idx % 10 < val_set_fraction * 10):
+                    # Slap it to Val
+                    self.val_images.append(str(self.image_list[set_idx]))
+                    self.val_labels.append(self.label_list[set_idx])
+                    self.N_vals += 1 
+                else:
+                    # Slap it to Train
+                    self.train_images.append(str(self.image_list[set_idx]))
+                    self.train_labels.append(self.label_list[set_idx])
+                    self.N_trains += 1
 
-        for img_idx in range (0, self.N_images):
-            current_gacha = random.random()
-            if (current_gacha <= val_set_fraction):
-                self.val_images.append(str(self.image_list[img_idx]))
-                self.val_labels.append(self.label_list[str(str(img_idx).zfill(6))])
-                self.num_val_samples += 1 
-            else:
-                self.train_images.append(str(self.image_list[img_idx]))
-                self.train_labels.append(self.label_list[str(str(img_idx).zfill(6))])
-                self.num_train_samples += 1
-
-        print(f"Dataset {self.dataset_name} loaded with {self.num_train_samples} trains and {self.num_val_samples} vals.")
-        print(f"Val/Total = {self.num_val_samples / self.num_train_samples + self.num_val_samples}")
+        print(f"Dataset {self.dataset_name} loaded with {self.N_trains} trains and {self.N_vals} vals.")
+        print(f"Val/Total = {self.N_vals / (self.N_trains + self.N_vals)}")
 
     def getItemCount(self):
-        return self.num_train_samples, self.num_val_samples
+        return self.N_trains, self.N_vals
     
 
 if __name__ == "__main__":

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -10,6 +10,7 @@ from PIL import Image, ImageDraw
 import warnings
 from datetime import datetime
 from typing import Literal, get_args
+from .check_data import CheckData
 
 VALID_DATASET_LITERALS = Literal[
     "BDD100K", 
@@ -42,28 +43,25 @@ class LoadDataEgoPath():
         # ================= Preliminary checks ================= #
 
         if not (0 <= self.val_set_fraction <= 1):
-            raise ValueError(f"val_set_fraction must be within [0, 1]. Current set to {self.val_set_fraction}")
+            raise ValueError(f"val_set_fraction must be within [0, 1]. Currently set to {self.val_set_fraction}")
 
         if not (self.dataset_name in VALID_DATASET_LIST):
             raise ValueError("Unknown dataset! Contact our team so we can work on this.")
         
         with open(self.label_filepath, "r") as f:
-            self.label_list = json.load(f)
-        self.image_list = sorted([
+            self.labels = json.load(f)
+        self.images = sorted([
             f for f in pathlib.Path(self.image_dirpath).glob("*.png")
         ])
 
-        self.N_labels = len(self.label_list)
-        self.N_images = len(self.image_list)
+        self.N_labels = len(self.labels)
+        self.N_images = len(self.images)
 
-        if (self.N_labels != self.N_images):
-            raise ValueError(f"Number of images ({self.N_images}) does not match number of labels ({self.N_labels})")
-        
-        if (self.N_labels == 0):
-            raise ValueError(f"No labels found in specified path {self.label_filepath}")
-        
-        if (self.N_images == 0):
-            raise ValueError(f"No images found in specified path {self.image_dirpath}")
+        # Sanity check func by Mr. Zain
+        checkData = CheckData(
+            self.N_images,
+            self.N_labels
+        )
         
         # ================= Initiate data loading ================= #
 

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -1,16 +1,9 @@
 #! /usr/bin/env python3
 
-import argparse
 import json
-import os
-import random
-import shutil
 import pathlib
-from PIL import Image, ImageDraw
-import warnings
-from datetime import datetime
 from typing import Literal, get_args
-from .check_data import CheckData
+from check_data import CheckData
 
 VALID_DATASET_LITERALS = Literal[
     "BDD100K", 
@@ -77,17 +70,17 @@ class LoadDataEgoPath():
             for set_idx, label_content in enumerate(self.labels):
                 if (set_idx % 10 < val_set_fraction * 10):
                     # Slap it to Val
-                    self.val_images.append(str(self.image_list[set_idx]))
-                    self.val_labels.append(self.label_list[set_idx])
+                    self.val_images.append(str(self.images[set_idx]))
+                    self.val_labels.append(self.labels[label_content])
                     self.N_vals += 1 
                 else:
                     # Slap it to Train
-                    self.train_images.append(str(self.image_list[set_idx]))
-                    self.train_labels.append(self.label_list[set_idx])
+                    self.train_images.append(str(self.images[set_idx]))
+                    self.train_labels.append(self.labels[label_content])
                     self.N_trains += 1
 
         print(f"Dataset {self.dataset_name} loaded with {self.N_trains} trains and {self.N_vals} vals.")
-        print(f"Val/Total = {self.N_vals / (self.N_trains + self.N_vals)}")
+        print(f"Val/Total = {(self.N_vals / (self.N_trains + self.N_vals)):.4f}")
 
     def getItemCount(self):
         return self.N_trains, self.N_vals

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -10,3 +10,33 @@ from PIL import Image, ImageDraw
 import warnings
 from datetime import datetime
 from typing import Literal, get_args
+
+VALID_DATASET_LITERALS = Literal[
+    "BDD100K", 
+    "COMMA2K19", 
+    "CULANE", 
+    "CURVELANES", 
+    "ROADWORK", 
+    "TUSIMPLE"
+]
+VALID_DATASET_LIST = list(get_args(VALID_DATASET_LITERALS))
+
+
+
+class LoadDataEgoPath():
+    def __init__(
+            self, 
+            labels_filepath: str,
+            images_filepath: str,
+            dataset: VALID_DATASET_LITERALS,
+            val_set_fraction: float = 0.1,
+            random_seed = 0
+    ):
+        
+        # ================= Parsing param ================= #
+
+        self.label_filepath = labels_filepath
+        self.image_dirpath = images_filepath
+        self.dataset_name = dataset
+        self.val_set_fraction = val_set_fraction
+        self.random_seed = random_seed

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -1,0 +1,12 @@
+#! /usr/bin/env python3
+
+import argparse
+import json
+import os
+import random
+import shutil
+import pathlib
+from PIL import Image, ImageDraw
+import warnings
+from datetime import datetime
+from typing import Literal, get_args

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -91,3 +91,6 @@ class LoadDataEgoPath():
 
         print(f"Dataset {self.dataset_name} loaded with {self.num_train_samples} trains and {self.num_val_samples} vals.")
         print(f"Val/Total = {self.num_val_samples / self.num_train_samples + self.num_val_samples}")
+
+    def getItemCount(self):
+        return self.num_train_samples, self.num_val_samples

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -64,3 +64,30 @@ class LoadDataEgoPath():
         
         if (self.N_images == 0):
             raise ValueError(f"No images found in specified path {self.image_dirpath}")
+        
+        # ================= Initiate data loading ================= #
+
+        self.train_images = []
+        self.train_labels = []
+        self.val_images = []
+        self.val_labels = []
+
+        self.num_train_samples = 0
+        self.num_val_samples = 0
+
+        if (self.random_seed):
+            random.seed(self.random_seed)
+
+        for img_idx in range (0, self.N_images):
+            current_gacha = random.random()
+            if (current_gacha <= val_set_fraction):
+                self.val_images.append(str(self.image_list[img_idx]))
+                self.val_labels.append(self.label_list[str(str(img_idx).zfill(6))])
+                self.num_val_samples += 1 
+            else:
+                self.train_images.append(str(self.image_list[img_idx]))
+                self.train_labels.append(self.label_list[str(str(img_idx).zfill(6))])
+                self.num_train_samples += 1
+
+        print(f"Dataset {self.dataset_name} loaded with {self.num_train_samples} trains and {self.num_val_samples} vals.")
+        print(f"Val/Total = {self.num_val_samples / self.num_train_samples + self.num_val_samples}")

--- a/Models/data_utils/load_ego_path_data.py
+++ b/Models/data_utils/load_ego_path_data.py
@@ -40,3 +40,20 @@ class LoadDataEgoPath():
         self.dataset_name = dataset
         self.val_set_fraction = val_set_fraction
         self.random_seed = random_seed
+
+        # ================= Preliminary checks ================= #
+
+        if not (0 <= self.val_set_fraction <= 1):
+            raise ValueError(f"val_set_fraction must be within [0, 1]. Current set to {self.val_set_fraction}")
+
+        if not (self.dataset_name in VALID_DATASET_LIST):
+            raise ValueError("Unknown dataset! Contact our team so we can work on this.")
+        
+        with open(self.label_filepath, "r") as f:
+            self.label_list = json.load(f)
+        self.image_list = sorted([
+            f for f in pathlib.Path(self.image_dirpath).glob("*.png")
+        ])
+
+        self.N_labels = len(self.label_list)
+        self.N_images = len(self.image_list)


### PR DESCRIPTION
This pull request is to implement data loader for [EgoPath network training](https://github.com/autowarefoundation/autoware.privately-owned-vehicles/tree/main/EgoPath), addressed in issue #52 .

---

## Class `LoadDataEgoPath`

Parameters:

- `labels_filepath : str` - path to JSON file containing all label info (typically `drivable_path.json`).
- `images_filepath : str` - path to directory containing all original frames.
- `dataset : str` - name of the processed dataset, within these names of `["BDD100K", "COMMA2K19", "CULANE", "CURVELANES", "ROADWORK", "TUSIMPLE"]`

---

### Helper functions

#### `def getItemCount(self)`
Return the total number of training and validation samples associated with a dataset.

#### `def getItemTrain(self, index)`
Return the list of ego_path keypoint tuples and the associated ground truth image as a numpy array for a specific item within the train_paths list and train_images list, where the item number is index.

#### `def getItemVal(self, index)`
Same as above but for val.