### PR TITLE
[EgoPath] Augmentation

### DIFF
--- a/Models/data_utils/augmentations.py
+++ b/Models/data_utils/augmentations.py
@@ -184,7 +184,7 @@ class Augmentations():
                 mask = self.ground_truth
             )
             
-            self.augmented_data = self.adjust_shape["mask"]
+            self.augmented_data = self.adjust_shape["keypoints"]
             self.augmented_image = self.adjust_shape["image"]
 
             # Random image augmentations
@@ -201,7 +201,7 @@ class Augmentations():
                 image = self.image,
                 mask = self.ground_truth
             )
-            self.augmented_data = self.adjust_shape["mask"]
+            self.augmented_data = self.adjust_shape["keypoints"]
             self.augmented_image = self.adjust_shape["image"]
 
         return self.augmented_image, self.augmented_data

--- a/Models/data_utils/augmentations.py
+++ b/Models/data_utils/augmentations.py
@@ -66,16 +66,7 @@ class Augmentations():
             ]
         )
 
-        self.transform_shape_keypoints_flip_rotate = A.Compose(
-            [
-                A.Resize(width = 640, height = 320),
-                A.HorizontalFlip(p = 0.5),
-                A.Rotate(limit = 10, p = 1.0)
-            ],
-            keypoint_params = A.KeypointParams(format = "xy")
-        )
-
-        self.transform_shape_keypoints_flip = A.Compose(
+        self.transform_shape_keypoints = A.Compose(
             [
                 A.Resize(width = 640, height = 320),
                 A.HorizontalFlip(p = 0.5),
@@ -187,7 +178,6 @@ class Augmentations():
             self, 
             image: np.array, 
             ground_truth: list, 
-            is_rotate: bool
     ):
 
         if (self.data_type != "KEYPOINTS"):
@@ -198,17 +188,10 @@ class Augmentations():
         # For train set
         if (self.is_train):
 
-            # Resize, random horiztonal flip and 10-deg rotate
-            if (is_rotate):
-                self.adjust_shape = self.transform_shape_keypoints_flip_rotate(
-                    image = self.image,
-                    keypoints = self.ground_truth
-                )
-            else:
-                self.adjust_shape = self.transform_shape_keypoints_flip(
-                    image = self.image,
-                    keypoints = self.ground_truth
-                )
+            self.adjust_shape = self.transform_shape_keypoints(
+                image = self.image,
+                keypoints = self.ground_truth
+            )
             
             self.augmented_image = self.adjust_shape["image"]
             self.augmented_data = self.adjust_shape["keypoints"]

--- a/Models/data_utils/augmentations.py
+++ b/Models/data_utils/augmentations.py
@@ -1,13 +1,15 @@
 #! /usr/bin/env python3
 
-import os
 import random
 import albumentations as A
 import numpy as np
 from typing import Literal, get_args
-from PIL import Image, ImageDraw
 
-DATA_TYPES_LITERAL = Literal['SEGMENTATION', 'DEPTH', 'KEYPOINTS']
+DATA_TYPES_LITERAL = Literal[
+    "SEGMENTATION", 
+    "DEPTH", 
+    "KEYPOINTS"
+]
 DATA_TYPES_LIST = list(get_args(DATA_TYPES_LITERAL))
 
 class Augmentations():
@@ -237,51 +239,3 @@ class Augmentations():
             self.augmented_data = self.adjust_shape["keypoints"]
 
         return self.augmented_image, self.augmented_data
-    
-    # ================ This is to visually test the functions ================ #
-    
-    def sampleItemsAudit(
-            self,
-            is_rotate: bool,
-            np_img: np.array,
-            ego_path: list,
-            frame_id: int,
-            output_dir: str,
-    ):
-    
-        # Currently only for keypoints
-        CURRENTLY_SUPPORTED_DATATYPE = [
-            "KEYPOINTS"
-        ]
-
-        if (self.data_type not in CURRENTLY_SUPPORTED_DATATYPE):
-            raise ValueError(f"Data type set to {self.data_type}. Currently supporting {CURRENTLY_SUPPORTED_DATATYPE} data types only.")
-
-        # Process image & ego path
-        img = Image.fromarray(np_img)
-        # Renormalize ego path points
-        img_width, img_height = img.size
-        ego_path = [
-            (point[0] * img_width, point[1] * img_height) 
-            for point in ego_path
-        ]
-        # Augmentation
-        augmented_np_img, augmented_ego_path = self.applyTransformKeypoint(
-            image = np_img,
-            ground_truth = ego_path,
-            is_rotate = is_rotate
-        )
-        # Draw
-        augmented_img = Image.fromarray(augmented_np_img)
-        augmented_ego_path = [(x, y) for [x, y] in augmented_ego_path]
-        lane_color = (255, 255, 0)
-        lane_w = 5
-        frame_name = str(frame_id).zfill(5) + f"_aug.png"
-        draw = ImageDraw.Draw(augmented_img)
-        draw.line(
-            augmented_ego_path, 
-            fill = lane_color, 
-            width = lane_w
-        )
-        # Save
-        augmented_img.save(os.path.join(output_dir, frame_name))

--- a/Models/data_utils/augmentations.py
+++ b/Models/data_utils/augmentations.py
@@ -26,6 +26,8 @@ class Augmentations():
         self.data_type = data_type
         if not (self.data_type in DATA_TYPES_LIST):
             raise ValueError('Dataset type is not correctly specified')
+        
+        # ========================== Shape transforms ========================== #
 
         self.transform_shape = A.Compose(
             [
@@ -48,6 +50,23 @@ class Augmentations():
             ]
         )
 
+        self.transform_shape_keypoints = A.Compose(
+            [
+                A.Resize(width = 640, height = 320),
+                A.HorizontalFlip(p = 0.5),
+            ],
+            keypoint_params = A.KeypointParams(format = "xy")
+        )
+
+        self.transform_shape_keypoints_test = A.Compose(
+            [
+                A.Resize(width = 640, height = 320)
+            ],
+            keypoint_params = A.KeypointParams(format = "xy")
+        )
+
+        # ========================== Noise transforms ========================== #
+
         self.transform_noise = A.Compose(
             [      
                 A.MultiplicativeNoise(multiplier=(0.5, 1.5), per_channel=False, p=0.5),
@@ -66,19 +85,22 @@ class Augmentations():
             ]
         )
 
-        self.transform_shape_keypoints = A.Compose(
-            [
-                A.Resize(width = 640, height = 320),
-                A.HorizontalFlip(p = 0.5),
-            ],
-            keypoint_params = A.KeypointParams(format = "xy")
-        )
-
-        self.transform_shape_keypoints_test = A.Compose(
-            [
-                A.Resize(width = 640, height = 320)
-            ],
-            keypoint_params = A.KeypointParams(format = "xy")
+        self.transform_noise_keypoints = A.Compose(
+            [      
+                A.MultiplicativeNoise(multiplier=(0.5, 1.5), per_channel=False, p=0.25),
+                A.PixelDropout(dropout_prob=0.025, per_channel=True, p=0.25),
+                A.ColorJitter(brightness=0.6, contrast=0.6, saturation=0.6, hue=0.2, p=0.25),
+                A.GaussNoise(var_limit=(50.0, 100.0), mean=0, noise_scale_factor=0.2, p=0.25),
+                A.GaussNoise(var_limit=(250.0, 250.0), mean=0, noise_scale_factor=1, p=0.25),
+                A.ISONoise(color_shift=(0.1, 0.5), intensity=(0.5, 0.5), p=0.25),
+                A.RandomFog(fog_coef_lower=0.1, fog_coef_upper=0.3, alpha_coef=0.2, p=0.25),
+                A.RandomFog(fog_coef_lower=0.7, fog_coef_upper=1.0, alpha_coef=0.04, p=0.25),
+                A.RandomRain(p=0.1),
+                A.Spatter(mean=(0.65, 0.65), std=(0.3, 0.3), gauss_sigma=(2, 2), \
+                    cutout_threshold=(0.68, 0.68), intensity=(0.3, 0.3), mode='rain', \
+                    p=0.1),
+                A.ToGray(num_output_channels=3, method='weighted_average', p=0.1)           
+            ]
         )
 
     # SEMANTIC SEGMENTATION
@@ -199,7 +221,7 @@ class Augmentations():
             # Random image augmentations
             if (random.random() >= 0.25 and self.is_train):
         
-                self.add_noise = self.transform_noise(image = self.augmented_image)
+                self.add_noise = self.transform_noise_keypoints(image = self.augmented_image)
                 self.augmented_image = self.add_noise["image"]
 
         # For test/val sets

--- a/Models/data_utils/augmentations.py
+++ b/Models/data_utils/augmentations.py
@@ -1,6 +1,7 @@
+import random
+import argparse
 import albumentations as A
 from typing import Literal, get_args
-import random
 
 DATA_TYPES_LITERAL = Literal['SEGMENTATION', 'DEPTH', 'KEYPOINTS']
 DATA_TYPES_LIST = list(get_args(DATA_TYPES_LITERAL))
@@ -181,11 +182,11 @@ class Augmentations():
             # Resize, random horiztonal flip and 10-deg rotate
             self.adjust_shape = self.transform_shape_keypoints(
                 image = self.image,
-                mask = self.ground_truth
+                keypoints = self.ground_truth
             )
             
-            self.augmented_data = self.adjust_shape["keypoints"]
             self.augmented_image = self.adjust_shape["image"]
+            self.augmented_data = self.adjust_shape["keypoints"]
 
             # Random image augmentations
             if (random.random() >= 0.25 and self.is_train):
@@ -199,9 +200,60 @@ class Augmentations():
             # Only resize in test/val
             self.adjust_shape = self.transform_shape_keypoints_test(
                 image = self.image,
-                mask = self.ground_truth
+                keypoints = self.ground_truth
             )
-            self.augmented_data = self.adjust_shape["keypoints"]
+            
             self.augmented_image = self.adjust_shape["image"]
+            self.augmented_data = self.adjust_shape["keypoints"]
 
         return self.augmented_image, self.augmented_data
+    
+
+if __name__ == "__main__":
+
+    # Testing cases here. Currently only for keypoints
+    CURRENTLY_SUPPORTED_DATATYPE = [
+        "KEYPOINTS"
+    ]
+
+    parser = argparse.ArgumentParser(
+        description = "Testing Augmentation functions"
+    )
+    parser.add_argument(
+        "--is_train",
+        type = bool,
+        help = "True if this is train set, False if otherwise",
+        required = True
+    )
+    parser.add_argument(
+        "--data_type",
+        type = str,
+        help = "Data type, either 'SEGMENTATION', 'DEPTH', or 'KEYPOINTS'",
+        required = True
+    )
+    parser.add_argument(
+        "--image_dirpath",
+        type = str,
+        help = "Path to raw image directory",
+        required = True
+    )
+    parser.add_argument(
+        "--label_filepath",
+        type = str,
+        help = "Path to drivable_path.json",
+        required = True
+    )
+    parser.add_argument(
+        "--early_stopping",
+        type = str,
+        help = "Num. of samples you wanna limit, instead of whole image dir.",
+        required = False
+    )
+    args = parser.parse_args()
+
+    is_train = args.is_train
+    data_type = args.data_type
+    image_dirpath = args.image_dirpath
+    label_filepath = args.label_filepath
+
+    

--- a/Models/data_utils/augmentations.py
+++ b/Models/data_utils/augmentations.py
@@ -230,7 +230,8 @@ class Augmentations():
         ]
 
         if (self.data_type not in CURRENTLY_SUPPORTED_DATATYPE):
-            raise ValueError(f"Data type set to {self.data_type}. Currently supporting {CURRENTLY_SUPPORTED_DATATYPE} data types only.")
+            raise ValueError(f"Data type set to {self.data_type}. \
+                             Currently supporting {CURRENTLY_SUPPORTED_DATATYPE} data types only.")
 
         # Process image & ego path
         img = Image.fromarray(np_img)
@@ -259,75 +260,3 @@ class Augmentations():
         )
         # Save
         augmented_img.save(os.path.join(output_dir, frame_name))
-
-
-if __name__ == "__main__":
-    # Testing cases here, running through all 6 datasets
-    # Feel free to change dir configs as per yours
-    # Below setting applies for this structure, which is by default:
-    
-    # |---- <datasets_repo>/
-    # |     |------ <dataset_name in UPPERCASE>/
-    # |     |       |------ image/
-    # |     |       |------ segmentation/
-    # |     |       |------ visualization/
-    # |     |       |------ drivable_path.json
-
-    datasets_repo = "/home/tranhuunhathuy/Documents/Autoware/pov_datasets/"
-    IS_TRAIN = True
-
-    print("Initializing Augmentation instance...")
-    AugInstance = Augmentations(
-        is_train = IS_TRAIN,
-        data_type = "KEYPOINTS"
-    )
-
-    N_SAMPLES = 100
-    print(f"Sampling {N_SAMPLES} frames from each dataset in {datasets_repo}")
-
-    for dataset_name in VALID_DATASET_LIST:
-
-        print(f"\n{dataset_name}\n")
-
-        TestDataset = LoadDataEgoPath(
-            labels_filepath = os.path.join(
-                datasets_repo, 
-                f"processed_{dataset_name}", 
-                "drivable_path.json"
-            ),
-            images_filepath = os.path.join(
-                datasets_repo, 
-                f"processed_{dataset_name}", 
-                "image"
-            ),
-            dataset = dataset_name,
-        )
-
-        # Make output dir
-        OUTPUT_DIR = os.path.join(
-            datasets_repo, 
-            f"processed_{dataset_name}", 
-            "augmentation_sample"
-        )
-        if os.path.exists(OUTPUT_DIR):
-            print(f"Output path exists. Deleting.")
-            shutil.rmtree(OUTPUT_DIR)
-        os.makedirs(OUTPUT_DIR)
-
-        # Sampling
-        for index in range(N_SAMPLES):
-            # Fetch numpy img and corresponding ego path
-            np_img, ego_path = (
-                TestDataset.getItemTrain(index)
-                if IS_TRAIN else
-                TestDataset.getItemVal(index)
-            )
-            # Sample that pair
-            AugInstance.sampleItemsAudit(
-                np_img = np_img,
-                ego_path = ego_path,
-                input_frame_id = index,
-                output_dir = OUTPUT_DIR,
-            )
-
-        print(f"Sampling all done, saved at {OUTPUT_DIR}")


### PR DESCRIPTION
This PR is to address issue #53 on keypoint augmentation features.

1. Work has been done at [Models/data_utils/augmentations.py](https://github.com/autowarefoundation/autoware.privately-owned-vehicles/blob/main/Models/data_utils/augmentations.py).
2. A bit change in `Literal` to include `KEYPOINTS` type in it and in `CheckData`.
3. Additional transformations:
    - `self.transform_shape_keypoints` for train set, which includes 640x320 resize, horizontal flip, and slight rotate.
    - `self.transform_shape_keypoints_test` for test/val sets, which includes only 640x320 resize.
4. Additional helper functions:
    - `def setDataKeypoints(self, image, ground_truth)`
    - `def applyTransformKeypoint(self, image, ground_truth)`