### PR TITLE
Fix `frame_id` mismatch error between `drivable_path.json` and image directories in CULane

### DIFF
--- a/EgoLanes/create_lane/CULane/process_culane.py
+++ b/EgoLanes/create_lane/CULane/process_culane.py
@@ -415,10 +415,12 @@ if __name__ == "__main__":
 
     # Parse data by batch
     data_master = {}
+    img_id_counter = -1
 
     for split in list_splits:
+        
         print(f"\n==================== Processing {split} data ====================\n")
-        img_id_counter = -1
+        
         if (split in ["train", "val"]):
             list_files = [os.path.join(dataset_dir, list_path, f"{split}.txt")]    # Train or Val set
         else:   # Test set and its lil more complicated

--- a/EgoPath/create_path/CULane/process_culane.py
+++ b/EgoPath/create_path/CULane/process_culane.py
@@ -400,10 +400,12 @@ if __name__ == "__main__":
 
     # Parse data by batch
     data_master = {}
+    img_id_counter = -1
 
     for split in list_splits:
+
         print(f"\n==================== Processing {split} data ====================\n")
-        img_id_counter = -1
+        
         if (split in ["train", "val"]):
             list_files = [os.path.join(dataset_dir, list_path, f"{split}.txt")]    # Train or Val set
         else:   # Test set and its lil more complicated


### PR DESCRIPTION
Currently CULane dataset parsing pipelines have a minor problem: the 6-digit frame ids are not the same between the image file names, and those registered in `drivable_path.json`. This is due to the fact that in the previous version of `process_culane.py`, the `img_id_counter` variable was placed INSIDE the loop between splits: `for split in list_splits:`, making it being reset after each split of `train`, `val` and `test`. This has been confirmed during yesterday meeting.

This patch successfully fixes that error on both `EgoPath` and `EgoLane`. @m-zain-khawaja I tested the id match on CULane's EgoPath using the data loader test run, so I believe it should be good now. I haven't run the EgoLane version but since EgoPath & EgoLane shares >95% similarity it should be fine.

P/S: @m-zain-khawaja shall I reupload the CULane dataset on Kaggle as well? Should be quick.