### PR TITLE
[EgoPath Data Loader] Refactor getItemTrain/Val into one, finish bug fix

### DIFF
--- a/Models/data_utils/load_data_ego_path.py
+++ b/Models/data_utils/load_data_ego_path.py
@@ -10,12 +10,12 @@ from typing import Literal, get_args
 from check_data import CheckData
 
 VALID_DATASET_LITERALS = Literal[
-    "BDD100K", 
-    "COMMA2K19", 
-    "CULANE", 
+    # "BDD100K", 
+    # "COMMA2K19", 
+    # "CULANE", 
     "CURVELANES", 
-    "ROADWORK", 
-    "TUSIMPLE"
+    # "ROADWORK", 
+    # "TUSIMPLE"
 ]
 VALID_DATASET_LIST = list(get_args(VALID_DATASET_LITERALS))
 COMMA2K19_SIZE = {
@@ -143,7 +143,7 @@ class LoadDataEgoPath():
                     (label[0][1] < stacking_threshold)
                 )
         ):
-            label.insert(0, morethan1_stack[-1])
+            label.insert(0, morethan1_stack[0])
         # Convert all of those points into sublists
         label = [[x, y] for [x, y] in label]
 

--- a/Models/data_utils/load_data_ego_path.py
+++ b/Models/data_utils/load_data_ego_path.py
@@ -132,14 +132,15 @@ class LoadDataEgoPath():
         # Filter out those y extremely close to 1.0
         # But under some certain conditions, add back last point of heap
         morethan1_stack = []
-        while (label[0][1] >= 0.99):
+        stacking_threshold = 0.99
+        while (label[0][1] >= stacking_threshold):
             morethan1_stack.append(label[0])
             label.pop(0)
         if (
             (len(morethan1_stack) >= 1) and
                 (
                     (len(label) <= 1) or 
-                    (label[0][1] < 1.0)
+                    (label[0][1] < stacking_threshold)
                 )
         ):
             label.insert(0, morethan1_stack[-1])

--- a/Models/data_utils/load_data_ego_path.py
+++ b/Models/data_utils/load_data_ego_path.py
@@ -131,18 +131,18 @@ class LoadDataEgoPath():
 
         # Filter out those y extremely close to 1.0
         # But under some certain conditions, add back last point of heap
-        morethan1_heap = []
+        morethan1_stack = []
         while (label[0][1] >= 0.99):
-            morethan1_heap.append(label[0])
+            morethan1_stack.append(label[0])
             label.pop(0)
         if (
-            (len(morethan1_heap) >= 1) and
+            (len(morethan1_stack) >= 1) and
                 (
                     (len(label) <= 1) or 
                     (label[0][1] < 1.0)
                 )
         ):
-            label.insert(0, morethan1_heap[-1])
+            label.insert(0, morethan1_stack[-1])
         # Convert all of those points into sublists
         label = [[x, y] for [x, y] in label]
 


### PR DESCRIPTION
1. Refactor `getItemTrain(self, index)` and `getItemVal(self, index)` into one single `getItem(self, index, is_train: bool)` which makes much more sense, as there have been a lot of changes in that process which I describe below.

2. Solve bugs occured in CurveLane dataset, including:
    - Points with `y >= 1.0` which will jeopardize subsequent Albumentation functions.
    - Simple filtering doesn't work with some edge cases in CurveLanes.

After thorough fixes and tests, I conclude this patch with a heuristic approach in aforementioned `getItem()` func:

```
- morethan1_stack = []
- Move all points whose y >= 0.99 from label to that stack
- Edge case handling:
IF (
    (stack has points) and
        ((only 1 point left in label) or 
        (current anchor in label < 0.99))
):
    Return the last point in stack to label

IF (current anchor of label has y >= 1.0):
    Make that y = 0.9999
```

3. Bring all the testing/sampling funcs into `train_ego_path.py` which will be included in #59 . Now the data loadder is clean.

I have thoroughly checked the results on ALL datasets, both train and val, pair-wise, and seems like everything is good. Although CurveLanes has some images whose anchor points deviate a lil bit from the original result, it looks good and acceptable. @m-zain-khawaja we can have a short meeting to check this out.