### PR TITLE
[CurveLanes] Fix persistent issues in data parsing process

### DIFF
--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -329,8 +329,6 @@ def parseAnnotations(
                 [(float(point["x"]), float(point["y"])) for point in line]
                 for line in read_data
             ]
-            print("Lines, freshly acquired:")
-            pprint(lines)
 
             # Interpolate each line in case it has too few points
             for i in range(len(lines)):
@@ -339,7 +337,6 @@ def parseAnnotations(
 
             new_img_height = init_img_height
             new_img_width = init_img_width
-            print(f"Image size before resize and crop: {new_img_width} x {new_img_height}")
 
             # Handle image resizing
             if (resize):
@@ -366,17 +363,12 @@ def parseAnnotations(
                 ] for line in lines]
                 new_img_height -= (CROP_TOP + CROP_BOTTOM)
                 new_img_width -= (CROP_LEFT + CROP_RIGHT)
-            print(f"Image size AFTER resize and crop: {new_img_width} x {new_img_height}")
-            print("Lanes, after resizing and cropping:")
-            pprint(lines)
             
             # Remove empty lanes
             lines = [line for line in lines if (line and len(line) >= 2)]   # Pick lines with >= 2 points
             if (len(lines) < 2):    # Ignore frames with less than 2 lines
                 warnings.warn(f"Parsing {anno_path}: insufficient line amount after cropping: {len(lines)}")
                 return None
-            print("Lines, after removing empty lanes:")
-            pprint(lines)
             
             # Determine 2 ego lines via line anchors
 
@@ -393,8 +385,6 @@ def parseAnnotations(
                 lines[anchor[0]]
                 for anchor in line_anchors
             ]
-            print("Lines, after being sorted by anchors from left to right:")
-            pprint(lines)
 
             ego_indexes = getEgoIndexes(
                 [anchor[1] for anchor in line_anchors],
@@ -565,7 +555,7 @@ if __name__ == "__main__":
             for i in range(0, len(list_raw_files), sampling_step):
                 img_path = os.path.join(dataset_dir, ROOT_DIR, split, list_raw_files[i]).strip()
                 img_id_counter += 1
-                # print(img_id_counter)
+
                 # Preload image file for multiple uses later
                 raw_img = Image.open(img_path).convert("RGB")
                 img_width, img_height = raw_img.size

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -155,15 +155,15 @@ def getDrivablePath(
                 j += 1
 
     # Extend drivable path to bottom edge of the frame
-    if ((len(drivable_path) >= 2) and (drivable_path[0][1] < new_img_height)):
+    if ((len(drivable_path) >= 2) and (drivable_path[0][1] < new_img_height - 1)):
         x1, y1 = drivable_path[1]
         x2, y2 = drivable_path[0]
         if (x2 == x1):
             x_bottom = x2
         else:
             a = (y2 - y1) / (x2 - x1)
-            x_bottom = x2 + (new_img_height - y2) / a
-        drivable_path.insert(0, (x_bottom, new_img_height))
+            x_bottom = x2 + (new_img_height - 1 - y2) / a
+        drivable_path.insert(0, (x_bottom, new_img_height - 1))
 
     # Extend drivable path to be on par with longest ego line
     # By making it parallel with longer ego line


### PR DESCRIPTION
As discussed during previous meetings, CurveLanes, due to its nature of having "weird" line annotations (I don't want to say the annotators were lazy, but for God's sake the labels are truly messed up in quite some frames), as well as the fact that my parsing process was suboptimal in some edge cases, making it being a trouble for downstream tasks, including data loading, augmenting, and so on.

Since parsing these datasets is a collective effort, there are minor issues in other datasets as well. While we can just conveniently address them in downstream tasks, which works for CULane's mismatch IDs and Comma2k19's non-normalized coords, the issues in CurveLanes prove to be way much more annoying to be done. Thus, after some meetings, I decided to return to CurveLanes, and fix it completely again.

## I. Issues

There are a lot of points whose y coordinates are greater than 1.0 which is not supposed to be.

## II. Solutions

### 1. Simply trimming them

Intuitively we can just ignore those points, but some cases they take a huge part of a line, making that line non-viable after trimming them. It's okay if the discarded lines being outer lines, but it's not okay with ego lines, such as case below, left is without trimming, and right being otherwise:

![image](https://github.com/user-attachments/assets/31c08359-b039-4974-92d1-e114a78128a7)

### 2. Interpolating the lines whose points are few

Basically, for each line, my algorithm excludes the points outside of ROI after each crop action:

```python
# Handle image cropping
if (crop):
    CROP_TOP = crop["TOP"]
    CROP_RIGHT = crop["RIGHT"]
    CROP_BOTTOM = crop["BOTTOM"]
    CROP_LEFT = crop["LEFT"]
    # Crop
    lines = [[
        (x - CROP_LEFT, y - CROP_TOP) for x, y in line
        if (
            (CROP_LEFT <= x <= (new_img_width - CROP_RIGHT)) and 
            (CROP_TOP <= y <= (new_img_height - CROP_BOTTOM))
        )
    ] for line in lines]
    new_img_height -= (CROP_TOP + CROP_BOTTOM)
    new_img_width -= (CROP_LEFT + CROP_RIGHT)
```

(also there was a typo in this part, props to @sarun-hub for helping me spot that)

In normal cases, that exclusion works fine, but there are cases when a line ONLY HAS 2-3 POINTS (yes, welcome to CurveLanes), in which after crop exclusion only has 1 point left, then that line will be ignored since it does not meet following condition to be considered a "proper line":

```python
lanes = [lane for lane in lanes if (lane and len(lane) >= 2)]   # Pick lanes with >= 2 points
```

Thus, in order to deal with this, my approach includes:

1. Set a threshold `LINE_INTERP_THRESHOLD`, default by `5`.
2. For each line, if number of points is lower than that threshold, conduct interpolation to place additional evenly-spaced points onto that line. This is done by function `interpLine(line: list, points_quota: int)`.

This will make sure each line has at least `LINE_INTERP_THRESHOLD` points, which will make it safer during crop actions. 

## III. Results

I believe this fix ultimately solves the persistent CurveLanes issues, and actually there are much more frames being outputed using this new approach (because we have less frames being discarded due to improper trimming) - `19,575` frames compared with `18,324` frames on older version, both on sampling rate of `5`. New frames seem to have better quality compared to previous version, which is a strong indication that the algorithm works fine now.

@m-zain-khawaja let's discuss in the meeting.