### PR TITLE
Autoware POV Audit tool

### DIFF
--- a/Models/data_utils/manual_audit_app.py
+++ b/Models/data_utils/manual_audit_app.py
@@ -1,0 +1,243 @@
+# © 2025 TranHuuNhatHuy <huy9515@gmail.com>
+# Autoware POV Frame-by-frame Manual Audit tool
+
+import os
+import json
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from PIL import Image, ImageTk
+
+
+STATE_FILE = "audit_state.json"
+STATUS_FLASH_MS = 200
+FLASH_BORDER_W = 10
+
+
+class ImageAuditorApp:
+    def __init__(self, root):
+
+        self.root = root
+        self.root.title("Antoware POV - Tran's Frame Manual Auditor")
+
+        self.border_frame = tk.Frame(root, bd = FLASH_BORDER_W)
+        self.border_frame.pack()
+        self.image_label = tk.Label(self.border_frame)
+        self.image_label.pack()
+
+        self.accepted_images = []
+        self.rejected_images = []
+        self.image_files = []
+        self.current_index = 0
+
+        self.select_folder_and_resume()
+        self.setup_bindings()
+        self.setup_buttons_counters()
+        self.update_counters()
+
+
+    def setup_bindings(self):
+        self.root.bind("1", self.accept_image)
+        self.root.bind("2", self.reject_image)
+        self.root.bind("3", self.end_session)
+
+    
+    def update_counters(self):
+        self.accepted_var.set(f"Accepted: {len(self.accepted_images)}")
+        self.rejected_var.set(f"Rejected: {len(self.rejected_images)}")
+        self.total_var.set(f"Total: {len(self.accepted_images) + len(self.rejected_images)}")
+
+
+    def setup_buttons_counters(self):
+        # For buttons
+        frame = tk.Frame(self.root)
+        frame.pack(fill = tk.X)
+
+        list_btns = [
+            # Accept
+            tk.Button(
+                frame, 
+                text = "1: Accept", 
+                command = self.accept_image
+            ),
+            # Reject
+            tk.Button(
+                frame, 
+                text = "2: Reject", 
+                command = self.reject_image
+            ),
+            # Save & Quit
+            tk.Button(
+                frame, 
+                text = "3: Save & quit", 
+                command = self.end_session
+            )
+        ]
+
+        for btn in list_btns:
+            btn.pack(
+                side = tk.LEFT, 
+                expand = True, 
+                fill = tk.X
+            )
+
+        # For counter textboxes
+        counter_frame = tk.Frame(self.root)
+        counter_frame.pack(fill = tk.X)
+
+        self.accepted_var = tk.StringVar()
+        self.rejected_var = tk.StringVar()
+        self.total_var = tk.StringVar()
+
+        self.update_counters()
+
+        for var in [self.accepted_var, self.rejected_var, self.total_var]:
+            tk.Label(
+                counter_frame, 
+                textvariable = var, 
+                relief = "sunken"
+            ).pack(
+                side = tk.LEFT, 
+                expand = True, 
+                fill = tk.X
+            )
+
+
+    def select_folder_and_resume(self):
+        folder_path = filedialog.askdirectory(
+            title = "Select folder containing PNG images"
+        )
+        if not folder_path:
+            messagebox.showerror("Error", "No folder selected. Exiting.")
+            self.root.quit()
+            return
+
+        self.image_files = sorted([
+            os.path.join(folder_path, f)
+            for f in os.listdir(folder_path)
+            if f.lower().endswith(".png")
+        ])
+
+        if not self.image_files:
+            messagebox.showinfo("Info", "No PNG images found. Try again lol.")
+            self.root.quit()
+            return
+
+        # Try to resume
+        if os.path.exists(STATE_FILE):
+            with open(STATE_FILE, "r") as f:
+                state = json.load(f)
+                if state.get("folder") == folder_path:
+                    self.current_index = state.get("index", 0)
+                    self.accepted_images = state.get("accepted", [])
+                    self.rejected_images = state.get("rejected", [])
+
+        self.show_image()
+
+
+    def show_image(self):
+        self.border_frame.config(highlightthickness = 0)
+
+        if self.current_index >= len(self.image_files):
+            self.finish_review()
+            return
+
+        img_path = self.image_files[self.current_index]
+        img = Image.open(img_path)
+        img.thumbnail((800, 800))
+        img_tk = ImageTk.PhotoImage(img)
+
+        self.image_label.configure(image = img_tk)
+        self.image_label.image = img_tk
+        self.root.title(f"[{self.current_index+1}/{len(self.image_files)}] Reviewing: {os.path.basename(img_path)}")
+
+
+    def accept_image(self, event = None):
+        self.accepted_images.append(self.image_files[self.current_index])
+        self.update_counters()
+        self.flash_feedback("accepted")
+        self.current_index += 1
+        self.save_state()
+        self.root.after(STATUS_FLASH_MS, self.show_image)
+
+
+    def reject_image(self, event = None):
+        self.rejected_images.append(self.image_files[self.current_index])
+        self.update_counters()
+        self.flash_feedback("rejected")
+        self.current_index += 1
+        self.save_state()
+        self.root.after(STATUS_FLASH_MS, self.show_image)
+
+    
+    def clear_border_and_continue(self):
+        self.border_frame.config(highlightthickness = 0)
+
+
+    def flash_feedback(self, status):
+        color = (
+            "green" if (status == "accepted")
+            else "red"
+        )
+        self.border_frame.config(
+            highlightbackground = color, 
+            highlightcolor = color, 
+            highlightthickness = FLASH_BORDER_W
+        )
+
+
+    def end_session(self, event = None):
+        self.save_state()
+
+        save_file = filedialog.asksaveasfilename(
+            defaultextension = ".json",
+            filetypes = [("JSON files", "*.json")],
+            title = "Save audit results"
+        )
+
+        if save_file:
+            results = {
+                "accepted": self.accepted_images,
+                "rejected": self.rejected_images
+            }
+            with open(save_file, "w") as f:
+                json.dump(
+                    results, f, 
+                    indent = 4
+                )
+            messagebox.showinfo("Saved", f"Results saved to:\n{save_file}")
+
+        if (
+            os.path.exists(STATE_FILE) and
+            self.current_index >= len(self.image_files)
+        ):
+            os.remove(STATE_FILE)
+        self.root.quit()
+
+
+    def finish_review(self):
+        messagebox.showinfo("Done", "All images have been reviewed!")
+        self.end_session()
+
+
+    def save_state(self):
+        folder_path = (
+            os.path.dirname(self.image_files[0]) 
+            if self.image_files else ""
+        )
+        state = {
+            "folder": folder_path,
+            "index": self.current_index,
+            "accepted": self.accepted_images,
+            "rejected": self.rejected_images
+        }
+        with open(STATE_FILE, "w") as f:
+            json.dump(
+                state, f,
+                indent = 4
+            )
+
+
+if __name__ == "__main__":
+    root = tk.Tk()
+    app = ImageAuditorApp(root)
+    root.mainloop()


### PR DESCRIPTION
As showcased in previous meetings, I'm adding this tool as a single Python file app in `Models/data_utils/manual_audit_app.py`. I use all Python built-in GUI libraries so no need to install/setup anything, should be running on any Python environments. To start:

1. Simply run `python manual_audit_app.py` (path might be varied, just point to the file).
2. Select the directory containing all of your images for auditting.
3. Simply enjoy the tool. Press "1" key to accept, "2" key to reject a frame. Think of it as a cheap Tinder knock-off for POV audit lol.
4. When you're done with current session, press "3" to save your current progress to a JSON file, and quit the tool.

[Screencast from 2025年04月17日 10時50分38秒.webm](https://github.com/user-attachments/assets/de0be95b-e8d8-4e1f-b718-d0aec996a1cb)

The tool will also creates and updates a temp file called `audit_state.json` to remember the previous working session's state so you can jump right where it was and continue working.

I made this tool hoping to help us unload some burdens in dataset manual auditting, a process that is very time-consuming and a bit annoying, but also something we cannot ignore for the sake of our models. Currently I just made it barely work on frame-based datasets like the ones in EgoPath, but towards the course of EgoLanes I will gradually update the tool and increase its usability. 

Hopefully me and all of you would have a bit easier experience with those datasets in the near future, using this tool.