### PR TITLE
[EgoPath] Bezier curve visualization & groundtruth

### DIFF
--- a/EgoPath/create_path/common/create_bezier_gt.py
+++ b/EgoPath/create_path/common/create_bezier_gt.py
@@ -1,11 +1,5 @@
-import torch
-from torchvision import transforms
-from torch import nn, optim
-from torch.utils.tensorboard import SummaryWriter
 import matplotlib.pyplot as plt
-import cv2
 from PIL import Image
-import numpy as np
 import argparse
 import os
 import sys
@@ -22,7 +16,7 @@ from Models.data_utils.load_data_ego_path import (
 
 if (__name__ == "__main__"):
 
-    # == Input args ==
+    # ================ Input args ================
 
     parser = argparse.ArgumentParser(
         description = "Process CurveLanes dataset - PathDet groundtruth generation"
@@ -39,7 +33,41 @@ if (__name__ == "__main__"):
     # Parse dirs
     dataset_dir = args.dataset_dir
 
-    # == Preprocess ==
+    IMAGES_DIR = "image"
+    JSON_PATH = "drivable_path.json"
+    BEZIER_DIR = "bezier-visualization"
+    BEZSON_PATH = "bezier_path.json"
 
-    list_subdirs = ["image", "segmentation", "visualization"]
-    json_path = "drivable_path.json"
+    # ================ Main process through all 6 ================
+
+    for dataset in VALID_DATASET_LIST:
+
+        this_dataloader = LoadDataEgoPath(
+            labels_filepath = os.path.join(dataset_dir, dataset, JSON_PATH),
+            images_filepath = os.path.join(dataset_dir, dataset, IMAGES_DIR),
+            dataset = dataset
+        )
+
+        # Merge back tran and val splits
+        # this_all_images = (this_dataloader.train_images + this_dataloader.val_images).sort()
+        # this_all_labels = (this_dataloader.train_labels + this_dataloader.val_labels).sort()
+
+        # Bezier gen
+        for is_train in [True, False]:
+
+            if (is_train):
+                split = "train"
+                N_samples = this_dataloader.N_trains
+            else:
+                split = "val"
+                N_samples = this_dataloader.N_vals
+            print(f"\tCurrent processing {split} split")
+
+            for i in range(N_samples):
+
+                img, bezier_curve, is_valid = this_dataloader.getItem(i, is_train)
+                bezier_curve = list(zip(
+                    bezier_curve[0 : : 2],
+                    bezier_curve[1 : : 2]
+                ))
+                print(bezier_curve)

--- a/EgoPath/create_path/common/create_bezier_gt.py
+++ b/EgoPath/create_path/common/create_bezier_gt.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import cv2
 from PIL import Image
 import numpy as np
+import argparse
 import os
 import sys
 sys.path.append(os.path.abspath(os.path.join(
@@ -20,4 +21,25 @@ from Models.data_utils.load_data_ego_path import (
 
 
 if (__name__ == "__main__"):
-    
+
+    # == Input args ==
+
+    parser = argparse.ArgumentParser(
+        description = "Process CurveLanes dataset - PathDet groundtruth generation"
+    )
+    parser.add_argument(
+        "-d", "--dataset_dir",
+        dest = "dataset_dir", 
+        type = str, 
+        help = f"Master dataset directory, should contain all 6 datasets: {VALID_DATASET_LIST}",
+        required = True
+    )
+    args = parser.parse_args()
+
+    # Parse dirs
+    dataset_dir = args.dataset_dir
+
+    # == Preprocess ==
+
+    list_subdirs = ["image", "segmentation", "visualization"]
+    json_path = "drivable_path.json"

--- a/EgoPath/create_path/common/create_bezier_gt.py
+++ b/EgoPath/create_path/common/create_bezier_gt.py
@@ -1,31 +1,34 @@
-import matplotlib.pyplot as plt
-from PIL import Image
+#! /usr/bin/env python3
+
 import argparse
+from PIL import Image, ImageDraw
 import os
 import sys
 sys.path.append(os.path.abspath(os.path.join(
     os.path.dirname(__file__), 
     "../../../"
 )))
+import shutil
+import json
+
 from Models.data_utils.load_data_ego_path import (
     LoadDataEgoPath, 
-    VALID_DATASET_LIST, 
-    VALID_DATASET_LITERALS
+    VALID_DATASET_LIST
 )
 
 # Evaluate the x, y coords of a bezier point list at a given t-param value
-def evaluate_bezier(self, bezier, t):
+def evaluate_bezier(bezier, t):
 
-        # Throw an error if parameter t is out of boudns
+        # Throw an error if parameter t is out of bounds
         if not (0 < t < 1):
             raise ValueError("Please ensure t parameter is in the range [0, 1]")
         
         # Evaluate cubic bezier curve for value of t in range [0, 1]
-        x = ((1-t)**3)*bezier[0][0] + 3*((1-t)**2)*t*bezier[0][2] \
-            + 3*(1-t)*(t**2)*bezier[0][4] + (t**3)*bezier[0][6]
+        x = ((1-t)**3)*bezier[0] + 3*((1-t)**2)*t*bezier[2] \
+            + 3*(1-t)*(t**2)*bezier[4] + (t**3)*bezier[6]
         
-        y = ((1-t)**3)*bezier[0][1] + 3*((1-t)**2)*t*bezier[0][3] \
-            + 3*(1-t)*(t**2)*bezier[0][5] + (t**3)*bezier[0][7]
+        y = ((1-t)**3)*bezier[1] + 3*((1-t)**2)*t*bezier[3] \
+            + 3*(1-t)*(t**2)*bezier[5] + (t**3)*bezier[7]
         
         return x, y
 
@@ -49,39 +52,121 @@ if (__name__ == "__main__"):
     # Parse dirs
     dataset_dir = args.dataset_dir
 
-    IMAGES_DIR = "image"
-    JSON_PATH = "drivable_path.json"
-    BEZIER_DIR = "bezier-visualization"
-    BEZSON_PATH = "bezier_path.json"
+    IMAGES_DIRNAME = "image"
+    JSON_PATHNAME = "drivable_path.json"
+    BEZIER_DIRNAME = "bezier-visualization"
+    BEZSON_PATHNAME = "bezier_path.json"
 
     # ================ Main process through all 6 ================
 
-    for dataset in VALID_DATASET_LIST:
+    for dataset in ["TUSIMPLE"]:
 
         this_dataloader = LoadDataEgoPath(
-            labels_filepath = os.path.join(dataset_dir, dataset, JSON_PATH),
-            images_filepath = os.path.join(dataset_dir, dataset, IMAGES_DIR),
+            labels_filepath = os.path.join(dataset_dir, dataset, JSON_PATHNAME),
+            images_filepath = os.path.join(dataset_dir, dataset, IMAGES_DIRNAME),
             dataset = dataset
         )
 
-        # Merge back tran and val splits
-        # this_all_images = (this_dataloader.train_images + this_dataloader.val_images).sort()
-        # this_all_labels = (this_dataloader.train_labels + this_dataloader.val_labels).sort()
+        # Prep JSON
+        bezson_dict = {}
+
+        # Prep bezier_visualization
+        bezier_dir = os.path.join(dataset_dir, dataset, BEZIER_DIRNAME)
+        if (os.path.exists(bezier_dir)):
+            shutil.rmtree(bezier_dir)
+        os.makedirs(bezier_dir)
+
+        invalid_count = 0
 
         # Bezier gen
         for is_train in [True, False]:
 
             if (is_train):
                 split = "train"
-                N_samples = this_dataloader.N_trains
+                images = this_dataloader.train_images
             else:
                 split = "val"
-                N_samples = this_dataloader.N_vals
-            print(f"\tCurrent processing {split} split")
+                images = this_dataloader.val_images
+            print(f"\tCurrently processing {split} split...")
 
-            for i in range(N_samples):
+            # Thru each sample
+            for i, img_path in enumerate(images):
+
+                # Image ID
+                img_id = img_path.split("/")[-1].replace(".png", "")
 
                 img, bezier_points, is_valid = this_dataloader.getItem(i, is_train)
-                
-                for step in range(2, 11):
-                    t = step / 10
+                h, w, _ = img.shape
+
+                if (type(bezier_points) == int):
+                    invalid_count += 1
+                else:
+                    # Acquire bezier curve
+                    bezier_curve = []
+                    for step in range(2, 10, 1):
+                        t = step / 10
+                        x, y = evaluate_bezier(bezier_points, t)
+                        bezier_curve.append((x, y))
+                    # Draw
+                    img_pil = Image.fromarray(img)
+                    draw = ImageDraw.Draw(img_pil)
+                    pallete = {
+                        "point_red": (255, 0, 0), 
+                        "line_green": (0, 255, 0)
+                    }
+                    lane_w = 4
+
+                    # Curve
+                    draw.line(
+                        [(int(x * w), int(y * h)) for (x, y) in bezier_curve], 
+                        fill = pallete["line_green"], 
+                        width = lane_w // 2
+                    )
+
+                    # Points
+                    bezier_points = list(zip(
+                        bezier_points[0 : : 2],
+                        bezier_points[1 : : 2]
+                    ))
+                    for (x, y) in bezier_points:
+                        x_deno = int(x * w)
+                        y_deno = int(y * h)
+                        draw.ellipse(
+                            (
+                                x_deno - lane_w, y_deno - lane_w, 
+                                x_deno + lane_w, y_deno + lane_w
+                            ),
+                            fill = pallete["point_red"]
+                        )
+                    
+                    # Save
+                    img_pil.save(os.path.join(bezier_dir, f"{img_id}.jpg"))
+
+                    # Add to JSON, but first convert all to float64 
+                    # each 4-digit rounded to reduce JSON filesize
+                    bezier_points = [
+                        (round(float(p[0]), 4), round(float(p[1]), 4))
+                        for p in bezier_points
+                    ]
+                    bezier_curve = [
+                        (round(float(p[0]), 4), round(float(p[1]), 4))
+                        for p in bezier_curve
+                    ]
+                    bezson_dict[img_id] = {
+                        "points" : bezier_points,
+                        "curve"  : bezier_curve
+                    }
+                    
+            print(f"\tFinished processing {len(images)} samples of {split} split.")
+
+        # Dump JSON
+        bezson_path = os.path.join(dataset_dir, dataset, BEZSON_PATHNAME)
+        with open(bezson_path, "w") as f:
+            json.dump(
+                bezson_dict, f, 
+                indent = 4
+            )
+        print(f"\tFinished dumping JSON.")
+
+        print(f"Finish bezier visualization for dataset {dataset}.")
+        print(f"Number of invalid bezier fits: {invalid_count}\n")

--- a/EgoPath/create_path/common/create_bezier_gt.py
+++ b/EgoPath/create_path/common/create_bezier_gt.py
@@ -59,7 +59,7 @@ if (__name__ == "__main__"):
 
     # ================ Main process through all 6 ================
 
-    for dataset in ["TUSIMPLE"]:
+    for dataset in VALID_DATASET_LIST:
 
         this_dataloader = LoadDataEgoPath(
             labels_filepath = os.path.join(dataset_dir, dataset, JSON_PATHNAME),

--- a/EgoPath/create_path/common/create_bezier_gt.py
+++ b/EgoPath/create_path/common/create_bezier_gt.py
@@ -13,6 +13,22 @@ from Models.data_utils.load_data_ego_path import (
     VALID_DATASET_LITERALS
 )
 
+# Evaluate the x, y coords of a bezier point list at a given t-param value
+def evaluate_bezier(self, bezier, t):
+
+        # Throw an error if parameter t is out of boudns
+        if not (0 < t < 1):
+            raise ValueError("Please ensure t parameter is in the range [0, 1]")
+        
+        # Evaluate cubic bezier curve for value of t in range [0, 1]
+        x = ((1-t)**3)*bezier[0][0] + 3*((1-t)**2)*t*bezier[0][2] \
+            + 3*(1-t)*(t**2)*bezier[0][4] + (t**3)*bezier[0][6]
+        
+        y = ((1-t)**3)*bezier[0][1] + 3*((1-t)**2)*t*bezier[0][3] \
+            + 3*(1-t)*(t**2)*bezier[0][5] + (t**3)*bezier[0][7]
+        
+        return x, y
+
 
 if (__name__ == "__main__"):
 
@@ -65,9 +81,7 @@ if (__name__ == "__main__"):
 
             for i in range(N_samples):
 
-                img, bezier_curve, is_valid = this_dataloader.getItem(i, is_train)
-                bezier_curve = list(zip(
-                    bezier_curve[0 : : 2],
-                    bezier_curve[1 : : 2]
-                ))
-                print(bezier_curve)
+                img, bezier_points, is_valid = this_dataloader.getItem(i, is_train)
+                
+                for step in range(2, 11):
+                    t = step / 10

--- a/EgoPath/create_path/common/create_bezier_gt.py
+++ b/EgoPath/create_path/common/create_bezier_gt.py
@@ -1,0 +1,23 @@
+import torch
+from torchvision import transforms
+from torch import nn, optim
+from torch.utils.tensorboard import SummaryWriter
+import matplotlib.pyplot as plt
+import cv2
+from PIL import Image
+import numpy as np
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(
+    os.path.dirname(__file__), 
+    "../../../"
+)))
+from Models.data_utils.load_data_ego_path import (
+    LoadDataEgoPath, 
+    VALID_DATASET_LIST, 
+    VALID_DATASET_LITERALS
+)
+
+
+if (__name__ == "__main__"):
+    


### PR DESCRIPTION
Addressing #83 .

### Accomplishments

Added `EgoPath/create_path/common/create_bezier_gt.py`, which reads drivable path info and images from each of 6 datasets (dirpath acquired via args), then outputs a new folder called `bezier-visualization` that stores all bezier visualizations and a JSON file named `bezier_path.json` that stores bezier info.

So basically for each dataset, the previous file structure:

```
|------ <dataset name in UPPERCASE>/              # i.e. CURVELANES
|              |------ image/
|              |------ segmentation/
|              |------ visualization/
|              |------ drivable_path.json
```

now becomes:

```
|------ <dataset name in UPPERCASE>/              # i.e. CURVELANES
|              |------ bezier-visualization/
|              |------ image/
|              |------ segmentation/
|              |------ visualization/
|              |------ bezier_path.json
|              |------ drivable_path.json
```

Currently currently across all 6 datasets. Below is an example of the finished BDD100K:

[bezier_vis_bdd100k_demo.webm](https://github.com/user-attachments/assets/9b1845a2-276b-43c8-a603-f9f9321464d4)

