### PR TITLE
[EgoPath Network] CurveLanes dataset BEV parsing module

### DIFF
--- a/EgoPath/create_path/CurveLanes/README.md
+++ b/EgoPath/create_path/CurveLanes/README.md
@@ -131,3 +131,52 @@ python3 EgoPath/create_path/CurveLanes/process_curvelanes.py --dataset_dir ../po
     - `normalized` (bool): whether the coords are normalized to `[0, 1]`.
 - **Returns**: None
 
+### 3. `interpX(line, y)`
+
+- **Description**: interpolates the x-value of a line at a given y-coordinate.
+- **Parameters**:
+    - `line` (list): a list of `(x, y)` tuples representing the line points.
+    - `y` (float): the y-value at which to interpolate the x-value.
+- **Returns**: the interpolated x-value as a `float`.
+
+### 4. `polyfit_BEV(bev_egopath, order, y_step, y_limit)`
+
+- **Description**: fits a polynomial curve to the BEV path and generates evenly spaced points along the y-axis.
+- **Parameters**:
+    - `bev_egopath` (list): list of `(x, y)` points in BEV space.
+    - `order` (int): order of the polynomial fit, preferrably `2`.
+    - `y_step` (int): step size between y-values.
+    - `y_limit` (int): maximum y-value for interpolation.
+- **Returns**:
+    - `fitted_bev_egopath` (tuple): tuple of fitted `(x, y)` points.
+    - `flag_list` (list): list of booleans indicating whether each x is within valid bounds.
+
+### 5. `imagePointTuplize(point)`
+
+- **Description**: converts a point's coordinates to integers for image operations.
+- **Parameters**:
+    - `point` (tuple): a `(float, float)` point to be converted.
+- **Returns**: an `(int, int)` tuple of the converted point.
+
+### 6. `findSourcePointsBEV(h, w, egoleft, egoright)`
+
+- **Description**: computes four source points for homography transformation to BEV space.
+- **Parameters**:
+    - `h` (int): height of the image.
+    - `w` (int): width of the image.
+    - `egoleft` (list): normalized points representing the left ego lane.
+    - `egoright` (list): normalized points representing the right ego lane.
+- **Returns**: a dictionary with keys `LS`, `RS`, `LE`, `RE` for source points, and `ego_h` for ego lane height.
+
+### 7. `transformBEV(img, egopath, sps)`
+
+- **Description**: applies a perspective transform to convert the image and drivable path into BEV space.
+- **Parameters**:
+    - `img` (np.ndarray): original perspective-view image.
+    - `egopath` (list): drivable path in normalized coordinates.
+    - `sps` (dict): source points for the homography transform.
+- **Returns**:
+    - `im_dst` (np.ndarray): transformed BEV image.
+    - `bev_egopath` (list): polyfitted drivable path in BEV space.
+    - `flag_list` (list): boolean list indicating valid x-values in BEV space.
+    - `mat` (np.ndarray): homography matrix used for the transformation.

--- a/EgoPath/create_path/CurveLanes/README.md
+++ b/EgoPath/create_path/CurveLanes/README.md
@@ -113,14 +113,21 @@ python3 EgoPath/create_path/CurveLanes/process_curvelanes.py --dataset_dir ../po
 
 - **Description**: draws a polyline on an image given a list of points.
 - **Parameters**:
-    - `img` (np.ndarray): The image on which to draw the line.
-    - `anno_entry` (dict): Annotation data including lanes and drivable path.
-    - `raw_dir` (str): Directory to save raw images.
-    - `visualization_dir` (str): Directory to save annotated images.
-    - `mask_dir` (str): Directory to save segmentation masks.
-    - `init_img_width` (int): Original width of the image.
-    - `init_img_height` (int): Original height of the image.
-    - `normalized` (bool, optional): Whether coordinates are normalized. Defaults to `True`.
-    - `resize` (float, optional): Resize factor. Defaults to `None`.
-    - `crop` (dict, optional): Cropping dimensions. Defaults to `None`.
+    - `img` (np.ndarray): the image on which to draw the line.
+    - `line` (list): a list of `(x, y)` tuples representing the line points.
+    - `color` (tuple): the BGR color of the line.
+    - `thickness` (int, optional): thickness of the line. Defaults to `2`.
 - **Returns**: None
+
+### 2. `annotateGT(img, frame_id, bev_egopath, raw_dir, visualization_dir, normalized)`
+
+- **Description**: annotates and saves both raw and visualization images with the drivable path.
+- **Parameters**:
+    - `img` (np.ndarray): the BEV-transformed image.
+    - `frame_id` (str): identifier for current frame.
+    - `bev_egopath` (list): drivable path line in BEV space.
+    - `raw_dir` (str): directory to save the raw BEV image.
+    - `visualization_dir` (str): directory to save the BEV visualization image.
+    - `normalized` (bool): whether the coords are normalized to `[0, 1]`.
+- **Returns**: None
+

--- a/EgoPath/create_path/CurveLanes/README.md
+++ b/EgoPath/create_path/CurveLanes/README.md
@@ -107,7 +107,54 @@ This script processes annotated CurveLanes dataset frames to generate a bird-eye
 
 ## I. Algorithm
 
+### From EgoPath dataset
 
+From EgoPath datasets, each frame we have ground-truth info of:
+- Egolines, left ego line and right ego line.
+- Drivable path, derived from algorithm.
+- Other lanes, but for now no need to care about them.
+
+In order to conduct BEV transformation, we need 4 points of a frustum:
+- Left start (`LS`)
+- Right start (`RS`)
+- Left end (`LE`)
+- Right end (`RE`)
+
+### Step 1
+
+Acquire 2 anchors of left and right egolines:
+- Left anchor : $(x_{0L}, a_L, b_L)$ with anchor point $(x_{0L}, h)$
+- Right anchor : $(x_{0R}, a_R, b_R)$ with anchor point $(x_{0R}, h)$
+
+In which:
+- $x0$ : intercept of egoline and bottom edge of frame
+- `a, b` : linear constants of that egoline, at bottom edge.
+
+These 2 points will serve as left start and right start of the frustum - `LS` and `RS` - respectively.
+
+### Step 2
+
+- Get midpoint of 2 egolines `MS` (mid-start) at $x_{M_S} = (x_{0L} + x_{0R}) / 2$.
+- Get a tangential value $a_M$ at `MS` that is average of the 2 values $a_L$ and $a_R$.
+
+### Step 3
+
+- Extend from midpoint along $a_M$ until it intercepts the height of shorter egoline, denoted by `lower_ego_y`.
+- This new intercept point is denoted by `ME` (mid-end).
+
+### Step 4
+
+- Calculate the width between left and right egolines at $y_L = y_R = $ `lower_ego_y`.
+- This width is denoted by $𝚫D = 2𝚫d$
+
+### Step 5
+
+- At $y = $ `lower_ego_y`, obtain 2 points at $x = x_{M_E} ± 𝚫d$ (remember $𝚫D = 2𝚫d$).
+- These 2 points will serve as left end `LE` and right end `RE` of the frustum.
+
+### Step 6
+
+Now the frustum is completed, we can conduct BEV transformation based on the 4 source points left start (`LS`), right start (`RS`), left end (`LE`) and right end (`RE`).
 
 ## II. Usage
 

--- a/EgoPath/create_path/CurveLanes/README.md
+++ b/EgoPath/create_path/CurveLanes/README.md
@@ -158,6 +158,19 @@ Now the frustum is completed, we can conduct BEV transformation based on the 4 s
 
 ## II. Usage
 
+### 1. Args
+
+- `--dataset_dir` : path to **processed** CurveLane dataset directory, including `image`, `visualization` and `drivable_path.json`.
+- `--early_stopping` : optional. For debugging purpose. Force the process to halt upon reaching a certain amount of images.
+
+## 2. Execute
+
+```bash
+# `pov_datasets` includes `CURVELANES` which is the processed CurveLanes directory in this case
+# Process first 100 images, then stop (for a quick run, instead of going through ~100k processed images)
+python3 EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py --dataset_dir ../pov_datasets/CURVELANES --early_stopping 100
+```
+
 ## III. Functions
 
 ### 1. `drawLine(img, line, color, thickness=2)`

--- a/EgoPath/create_path/CurveLanes/README.md
+++ b/EgoPath/create_path/CurveLanes/README.md
@@ -38,8 +38,8 @@ Each image, upon being parsed into those functions, will have 2 params of `origi
 
 - `--dataset_dir` : path to CurveLane dataset directory, should contains exactly `Curvelanes` if you get it from Kaggle.
 - `--output_dir` : path to directory where you wanna save the images.
-- `--sampling_step` : optional. Basically tells the process to skip several images for increased model learning capability during the latter training.
-- `--early_stopping` : optional. For debugging purpose. Force the process to halt upon reaching a certain amount of images. Default is 5, which means process 1 image then skip 4, and continue.
+- `--sampling_step` : optional. Basically tells the process to skip several images for increased model learning capability during the latter training. Default is 5, which means process 1 image then skip 4, and continue.
+- `--early_stopping` : optional. For debugging purpose. Force the process to halt upon reaching a certain amount of images.
 
 ## 2. Execute
 

--- a/EgoPath/create_path/CurveLanes/README.md
+++ b/EgoPath/create_path/CurveLanes/README.md
@@ -53,41 +53,67 @@ python3 EgoPath/create_path/CurveLanes/process_curvelanes.py --dataset_dir ../po
 ## III. Functions
 
 ### 1. `normalizeCoords(lane, width, height)`
-- **Description**: Normalizes lane coordinates to a scale of `[0, 1]` based on image dimensions.
+- **Description**: normalizes lane coordinates to a scale of `[0, 1]` based on image dimensions.
 - **Parameters**:
-    - `lane` (list of tuples): List of `(x, y)` points defining a lane.
-    - `width` (int): Width of the image.
-    - `height` (int): Height of the image.
-- **Returns**: A list of normalized `(x, y)` points.
+    - `lane` (list of tuples): list of `(x, y)` points defining a lane.
+    - `width` (int): width of the image.
+    - `height` (int): height of the image.
+- **Returns**: a list of normalized `(x, y)` points.
 
 ### 2. `getLaneAnchor(lane, new_img_height)`
-- **Description**: Determines the "anchor" point of a lane, which helps in lane classification.
+- **Description**: determines the "anchor" point of a lane, which helps in lane classification.
 - **Parameters**:
-    - `lane` (list of tuples): List of `(x, y)` points representing a lane.
-    - `new_img_height` (int): Height of the resized or cropped image.
-- **Returns**: A tuple `(x0, a, b)` representing the x-coordinate of the anchor and the linear equation parameters `a` and `b` for the lane.
+    - `lane` (list of tuples): list of `(x, y)` points representing a lane.
+    - `new_img_height` (int): height of the resized or cropped image.
+- **Returns**: a tuple `(x0, a, b)` representing the x-coordinate of the anchor and the linear equation parameters `a` and `b` for the lane.
 
 ### 3. `getEgoIndexes(anchors, new_img_width)`
-- **Description**: Identifies two ego lanes (left and right) from a sorted list of lane anchors.
+- **Description**: identifies two ego lanes (left and right) from a sorted list of lane anchors.
 - **Parameters**:
-    - `anchors` (list of tuples): List of lane anchors sorted by x-coordinate.
-    - `new_img_width` (int): Width of the processed image.
-- **Returns**: A tuple `(left_ego_idx, right_ego_idx)` with the indexes of the two ego lanes or an error message if lanes are missing.
+    - `anchors` (list of tuples): list of lane anchors sorted by x-coordinate.
+    - `new_img_width` (int): width of the processed image.
+- **Returns**: a tuple `(left_ego_idx, right_ego_idx)` with the indexes of the two ego lanes or an error message if lanes are missing.
 
 ### 4. `getDrivablePath(left_ego, right_ego, new_img_height, new_img_width, y_coords_interp=False)`
-- **Description**: Computes the drivable path as the midpoint between two ego lanes.
+- **Description**: computes the drivable path as the midpoint between two ego lanes.
 - **Parameters**:
-    - `left_ego` (list of tuples): Points of the left ego lane.
-    - `right_ego` (list of tuples): Points of the right ego lane.
-    - `new_img_height` (int): Height of the processed image.
-    - `new_img_width` (int): Width of the processed image.
-    - `y_coords_interp` (bool, optional): Whether to interpolate y-coordinates for smoother curves. Defaults to `False`.
-- **Returns**: A list of `(x, y)` points representing the drivable path, or an error message if the path violates heuristics.
+    - `left_ego` (list of tuples): points of the left ego lane.
+    - `right_ego` (list of tuples): points of the right ego lane.
+    - `new_img_height` (int): height of the processed image.
+    - `new_img_width` (int): width of the processed image.
+    - `y_coords_interp` (bool, optional): whether to interpolate y-coordinates for smoother curves. Defaults to `False`.
+- **Returns**: a list of `(x, y)` points representing the drivable path, or an error message if the path violates heuristics.
 
 ### 5. `annotateGT(raw_img, anno_entry, raw_dir, visualization_dir, mask_dir, init_img_width, init_img_height, normalized=True, resize=None, crop=None)`
-- **Description**: Annotates and saves an image with lane markings, drivable path, and segmentation mask.
+- **Description**: annotates and saves an image with lane markings, drivable path, and segmentation mask.
 - **Parameters**:
-    - `raw_img` (PIL.Image): The original image.
+    - `raw_img` (PIL.Image): the original image.
+    - `anno_entry` (dict): annotation data including lanes and drivable path.
+    - `raw_dir` (str): directory to save raw images.
+    - `visualization_dir` (str): directory to save annotated images.
+    - `mask_dir` (str): directory to save segmentation masks.
+    - `init_img_width` (int): original width of the image.
+    - `init_img_height` (int): original height of the image.
+    - `normalized` (bool, optional): whether coordinates are normalized. Defaults to `True`.
+    - `resize` (float, optional): resize factor. Defaults to `None`.
+    - `crop` (dict, optional): cropping dimensions. Defaults to `None`.
+- **Returns**: None
+
+# CurveLane Dataset BEV (Bird-Eyes-View) Processing Script
+
+## Overview
+
+## I. Algorithm
+
+## II. Usage
+
+## III. Functions
+
+### 1. `drawLine(img, line, color, thickness=2)`
+
+- **Description**: draws a polyline on an image given a list of points.
+- **Parameters**:
+    - `img` (np.ndarray): The image on which to draw the line.
     - `anno_entry` (dict): Annotation data including lanes and drivable path.
     - `raw_dir` (str): Directory to save raw images.
     - `visualization_dir` (str): Directory to save annotated images.

--- a/EgoPath/create_path/CurveLanes/README.md
+++ b/EgoPath/create_path/CurveLanes/README.md
@@ -47,7 +47,7 @@ Each image, upon being parsed into those functions, will have 2 params of `origi
 # `pov_datasets` includes `Curvelanes` directory in this case
 # Sampling rate 5 (also by default)
 # Process first 100 images, then stop (for a quick run, instead of going through 150k images)
-python EgoPath/create_path/CurveLanes/process_curvelanes.py --dataset_dir ../pov_datasets --output_dir ../pov_datasets/Output --sampling_step 5 --early_stopping 100
+python3 EgoPath/create_path/CurveLanes/process_curvelanes.py --dataset_dir ../pov_datasets --output_dir ../pov_datasets/Output --sampling_step 5 --early_stopping 100
 ```
 
 ## III. Functions

--- a/EgoPath/create_path/CurveLanes/README.md
+++ b/EgoPath/create_path/CurveLanes/README.md
@@ -103,7 +103,11 @@ python3 EgoPath/create_path/CurveLanes/process_curvelanes.py --dataset_dir ../po
 
 ## Overview
 
+This script processes annotated CurveLanes dataset frames to generate a bird-eyes view (BEV) representation of the drivable path. It reads per-frame image and lane data, computes the BEV transform using ego-lane boundaries, projects the drivable path into BEV space, and saves both the transformed images and path data for downstream use (training, visualization, etc.).
+
 ## I. Algorithm
+
+
 
 ## II. Usage
 

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -68,3 +68,22 @@ def imagePointTuplize(point: PointCoords) -> ImagePointCoords:
     suitable for image operations.
     """
     return (int(point[0]), int(point[1]))
+
+
+# ============================== MAIN RUN ============================== #
+
+
+if __name__ == "__main__":
+
+    # DIRECTORY STRUCTURE
+
+    IMG_DIR = "image"
+    JSON_PATH = "drivable_path.json"
+
+    BEV_IMG_DIR = "image_bev"
+    BEV_VIS_DIR = "visualization_bev"
+    BEV_JSON_PATH = "drivable_path_bev.json"
+
+    # PARSING ARGS
+
+    

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -63,6 +63,32 @@ def interpMorePoints(
     return line
 
 
+def polyfit_BEV(
+    bev_egopath: list,
+    order: int,
+    y_step: int,
+    y_limit: int
+):
+    x = [point[0] for point in bev_egopath]
+    y = [point[1] for point in bev_egopath]
+    z = np.polyfit(y, x, order)
+    f = np.poly1d(z)
+    y_new = np.linspace(
+        0, y_limit - 1, 
+        y_step
+    )
+    x_new = f(y_new)
+
+    fitted_bev_egopath = tuple(zip(x_new, y_new))
+
+    flag_list = [
+        True if (0 <= point[0] <= BEV_W) else False
+        for point in fitted_bev_egopath
+    ]
+    
+    return fitted_bev_egopath, flag_list
+
+
 def imagePointTuplize(point: PointCoords) -> ImagePointCoords:
     """
     Parse all coords of an (x, y) point to int, making it
@@ -181,9 +207,15 @@ def transformBEV(
         for point in bev_egopath
     ]
 
-    
+    # Polyfit BEV egopath to get 33-coords format with flags
+    bev_egopath, flag_list = polyfit_BEV(
+        bev_egopath = bev_egopath,
+        order = POLYFIT_ORDER,
+        y_step = BEV_Y_STEP,
+        y_limit = BEV_H
+    )
 
-    return im_dst, bev_egopath, mat
+    return im_dst, bev_egopath, flag_list, mat
 
 
 # ============================== Main run ============================== #
@@ -213,7 +245,9 @@ if __name__ == "__main__":
 
     BEV_W = 320
     BEV_H = 640
-    BEV_Y_STEP = 20
+    BEV_Y_STEP = 20\
+    
+    POLYFIT_ORDER = 2
 
     # PARSING ARGS
 

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -388,18 +388,29 @@ if __name__ == "__main__":
             normalized = False
         )
 
-        # Round, normalize egopath, and sort by descending y
-        bev_egopath = sorted(
-            round_line_floats(
-                normalizeCoords(
-                    bev_egopath,
-                    width = BEV_W,
-                    height = BEV_H
-                )
+        # Round, normalize egopath, and sort by descending y (with flag)
+        zipped_path_flag = sorted(
+            zip(
+                round_line_floats(
+                    normalizeCoords(
+                        bev_egopath,
+                        width = BEV_W,
+                        height = BEV_H
+                    )
+                ),
+                flag_list
             ),
-            key = lambda point: point[1],
+            key = lambda point: point[0][1],
             reverse = True
         )
+        bev_egopath = [
+            zipped_ent[0]
+            for zipped_ent in zipped_path_flag
+        ]
+        flag_list = [
+            zipped_ent[1]
+            for zipped_ent in zipped_path_flag
+        ]
 
         # Register this frame GT to master JSON
         # Each point has tuple format (x, y, flag)

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -8,3 +8,34 @@ import math
 import warnings
 import numpy as np
 from PIL import Image, ImageDraw
+
+
+# ============================== Helper functions ============================== #
+
+
+def getLineAnchor(line, img_height):
+    """
+    Determine "anchor" point of a line, along some related params.
+    """
+    (x2, y2) = line[0]
+    (x1, y1) = line[1]
+
+    for i in range(1, len(line) - 1, 1):
+        if (line[i][0] != x2) & (line[i][1] != y2):
+            (x1, y1) = line[i]
+            break
+
+    if (x1 == x2) or (y1 == y2):
+        if (x1 == x2):
+            error_lane = "Vertical"
+        elif (y1 == y2):
+            error_lane = "Horizontal"
+        warnings.warn(f"{error_lane} line detected: {line}, with these 2 anchors: ({x1}, {y1}), ({x2}, {y2}).")
+        return (x1, None, None)
+    
+    a = (y2 - y1) / (x2 - x1)
+    deg = math.degrees(math.atan(-a)) % 180
+    b = y1 - a * x1
+    x0 = (img_height - b) / a
+
+    return (x0, a, b, deg)

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -42,3 +42,21 @@ def getLineAnchor(line, img_height):
     x0 = (img_height - b) / a
 
     return (x0, a, b, deg)
+
+
+def interpX(line, y):
+    """
+    Interpolate x-value of a point on a line, given y-value
+    """
+    points = np.array(line)
+    list_x = points[:, 0]
+    list_y = points[:, 1]
+
+    if not np.all(np.diff(list_y) > 0):
+        sort_idx = np.argsort(list_y)
+        list_y = list_y[sort_idx]
+        list_x = list_x[sort_idx]
+
+    return float(np.interp(y, list_y, list_x))
+
+

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -106,6 +106,9 @@ if __name__ == "__main__":
 
     # Parse dataset dir
     dataset_dir = args.dataset_dir
+    IMG_DIR = os.path.join(dataset_dir, IMG_DIR)
+    JSON_PATH = os.path.join(dataset_dir, JSON_PATH)
+    BEV_JSON_PATH = os.path.join(dataset_dir, BEV_JSON_PATH)
 
     # Parse early stopping
     if (args.early_stopping):
@@ -123,4 +126,16 @@ if __name__ == "__main__":
     if not (os.path.exists(BEV_VIS_DIR)):
         os.makedirs(BEV_VIS_DIR)
 
-    
+    # Preparing data
+    with open(JSON_PATH, "r") as f:
+        json_data = json.load(f)
+
+    # MAIN GENERATION LOOP
+
+    for frame_id, frame_content in enumerate(json_data):
+
+        frame_img_path = os.path.join(
+            IMG_DIR,
+            f"{frame_id}.png"
+        )
+        this_frame_data = json_data[frame_id]

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -1,0 +1,10 @@
+#! /usr/bin/env python3
+
+import argparse
+import json
+import os
+import shutil
+import math
+import warnings
+import numpy as np
+from PIL import Image, ImageDraw

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -8,6 +8,9 @@ import math
 import warnings
 import numpy as np
 from PIL import Image, ImageDraw
+from .process_curvelanes import custom_warning_format, round_line_floats
+
+warnings.formatwarning = custom_warning_format
 
 
 # ============================== Helper functions ============================== #

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -369,7 +369,7 @@ if __name__ == "__main__":
         )
 
         # Transform to BEV space
-        im_dst, bev_egopath, mat = transformBEV(
+        im_dst, bev_egopath, flag_list, mat = transformBEV(
             img = img,
             egopath = this_frame_data["drivable_path"],
             sps = sps_dict
@@ -385,7 +385,20 @@ if __name__ == "__main__":
             normalized = False
         )
 
+        # Register this frame GT to master JSON
+        this_frame_payload = {}
+        for point, flag in list(zip(bev_egopath, flag_list)):
+            this_frame_payload[point[1]] = {
+                "x" : point[0],
+                "is_valid" : flag
+            }
+        data_master[frame_id] = this_frame_payload
+
         # Break if early_stopping reached
         if (early_stopping is not None):
             if (counter >= early_stopping):
                 break
+
+    # Save master data
+    with open(BEV_JSON_PATH, "w") as f:
+        json.dump(data_master, f, indent = 4)

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -12,6 +12,8 @@ from .process_curvelanes import custom_warning_format, round_line_floats
 
 warnings.formatwarning = custom_warning_format
 
+PointCoords = tuple[float, float]
+ImagePointCoords = tuple[int, int]
 
 # ============================== Helper functions ============================== #
 
@@ -60,3 +62,9 @@ def interpX(line, y):
     return float(np.interp(y, list_y, list_x))
 
 
+def imagePointTuplize(point: PointCoords) -> ImagePointCoords:
+    """
+    Parse all coords of an (x, y) point to int, making it
+    suitable for image operations.
+    """
+    return (int(point[0]), int(point[1]))

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -70,7 +70,7 @@ def imagePointTuplize(point: PointCoords) -> ImagePointCoords:
     return (int(point[0]), int(point[1]))
 
 
-# ============================== MAIN RUN ============================== #
+# ============================== Main run ============================== #
 
 
 if __name__ == "__main__":
@@ -85,5 +85,42 @@ if __name__ == "__main__":
     BEV_JSON_PATH = "drivable_path_bev.json"
 
     # PARSING ARGS
+
+    parser = argparse.ArgumentParser(
+        description = "Generating BEV from CurveLanes processed datasets"
+    )
+    parser.add_argument(
+        "--dataset_dir", 
+        type = str, 
+        help = "Processed CurveLanes directory",
+        required = True
+    )
+    # For debugging only
+    parser.add_argument(
+        "--early_stopping",
+        type = int,
+        help = "Num. frames you wanna limit, instead of whole set.",
+        required = False
+    )
+    args = parser.parse_args()
+
+    # Parse dataset dir
+    dataset_dir = args.dataset_dir
+
+    # Parse early stopping
+    if (args.early_stopping):
+        print(f"Early stopping set, each split/class stops after {args.early_stopping} files.")
+        early_stopping = args.early_stopping
+    else:
+        early_stopping = None
+
+    # Generate new dirs and paths
+    BEV_IMG_DIR = os.path.join(dataset_dir, BEV_IMG_DIR)
+    BEV_VIS_DIR = os.path.join(dataset_dir, BEV_VIS_DIR)
+
+    if not (os.path.exists(BEV_IMG_DIR)):
+        os.makedirs(BEV_IMG_DIR)
+    if not (os.path.exists(BEV_VIS_DIR)):
+        os.makedirs(BEV_VIS_DIR)
 
     

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -7,9 +7,7 @@ import shutil
 import math
 from PIL import Image, ImageDraw
 import warnings
-from datetime import datetime
 import numpy as np
-from pprint import pprint
 
 anomaly_dict = {
     "one-sided-anchors" : {
@@ -546,11 +544,11 @@ if __name__ == "__main__":
         sampling_step = args.sampling_step
     else:
         sampling_step = 1
-    pprint(f"Sampling step set to {sampling_step}.")
+    print(f"Sampling step set to {sampling_step}.")
 
     # Parse early stopping
     if (args.early_stopping):
-        pprint(f"Early stopping set, each split/class stops after {args.early_stopping} files.")
+        print(f"Early stopping set, each split/class stops after {args.early_stopping} files.")
         early_stopping = args.early_stopping
     else:
         early_stopping = None

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -34,11 +34,13 @@ anomaly_dict = {
 
 
 def round_line_floats(line, ndigits = 6):
+    line = list(line)
     for i in range(len(line)):
         line[i] = [
             round(line[i][0], ndigits),
             round(line[i][1], ndigits)
         ]
+    line = tuple(line)
     return line
 
 

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -5,9 +5,9 @@ import json
 import os
 import shutil
 import math
-from PIL import Image, ImageDraw
 import warnings
 import numpy as np
+from PIL import Image, ImageDraw
 
 
 anomaly_dict = {
@@ -33,21 +33,13 @@ anomaly_dict = {
 # ============================= Format functions ============================= #
 
 
-def round_floats(obj, ndigits = 6):
-    if isinstance(obj, float):
-        return round(obj, ndigits)
-    elif isinstance(obj, list):
-        return [
-            round_floats(item, ndigits) 
-            for item in obj
+def round_line_floats(line, ndigits = 6):
+    for i in range(len(line)):
+        line[i] = [
+            round(line[i][0], ndigits),
+            round(line[i][1], ndigits)
         ]
-    elif isinstance(obj, dict):
-        return {
-            key: round_floats(val, ndigits) 
-            for key, val in obj.items()
-        }
-    else:
-        return obj
+    return line
 
 
 def add_anomaly(frame_id, anomaly_code, drivable_path = None):
@@ -61,7 +53,6 @@ def add_anomaly(frame_id, anomaly_code, drivable_path = None):
 # Custom warning format cuz the default one is wayyyyyy too verbose
 def custom_warning_format(message, category, filename, lineno, line = None):
     return f"WARNING : {message}\n"
-
 
 warnings.formatwarning = custom_warning_format
 
@@ -653,9 +644,9 @@ if __name__ == "__main__":
                     # Save as 6-digit incremental index
                     img_index = str(str(img_id_counter).zfill(6))
                     data_master[img_index] = {}
-                    data_master[img_index]["drivable_path"] = this_data["drivable_path"]
-                    data_master[img_index]["egoleft_lane"] = this_data["egoleft_lane"]
-                    data_master[img_index]["egoright_lane"] = this_data["egoright_lane"]
+                    data_master[img_index]["drivable_path"] = round_line_floats(this_data["drivable_path"])
+                    data_master[img_index]["egoleft_lane"] = round_line_floats(this_data["egoleft_lane"])
+                    data_master[img_index]["egoright_lane"] = round_line_floats(this_data["egoright_lane"])
                     data_master[img_index]["img_height"] = this_data["img_height"]
                     data_master[img_index]["img_width"] = this_data["img_width"]
 
@@ -664,7 +655,6 @@ if __name__ == "__main__":
                         break
 
     # Save master data
-    rounded_data_master = round_floats(data_master)
     with open(os.path.join(output_dir, "drivable_path.json"), "w") as f:
         json.dump(data_master, f, indent = 4)
 

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -509,8 +509,8 @@ if __name__ == "__main__":
 
     # ====== Heuristic boundaries of drivable path for automatic auditing ====== #
 
-    LEFT_ANCHOR_BOUNDARY = RIGHT_ANCHOR_BOUNDARY = 0.35
-    HEIGHT_BOUNDARY = 0.3
+    LEFT_ANCHOR_BOUNDARY = RIGHT_ANCHOR_BOUNDARY = 0.25
+    HEIGHT_BOUNDARY = 0.15
     ANGLE_BOUNDARY = 30
 
     # ============================== Parsing args ============================== #

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -9,6 +9,7 @@ from PIL import Image, ImageDraw
 import warnings
 import numpy as np
 
+
 anomaly_dict = {
     "one-sided-anchors" : {
         "count" : 0,
@@ -28,6 +29,27 @@ anomaly_dict = {
     },
 }
 
+
+# ============================= Format functions ============================= #
+
+
+def round_floats(obj, ndigits = 6):
+    if isinstance(obj, float):
+        return round(obj, ndigits)
+    elif isinstance(obj, list):
+        return [
+            round_floats(item, ndigits) 
+            for item in obj
+        ]
+    elif isinstance(obj, dict):
+        return {
+            key: round_floats(val, ndigits) 
+            for key, val in obj.items()
+        }
+    else:
+        return obj
+
+
 def add_anomaly(frame_id, anomaly_code, drivable_path = None):
     anomaly_dict[anomaly_code]["count"] += 1
     if (drivable_path):
@@ -35,13 +57,17 @@ def add_anomaly(frame_id, anomaly_code, drivable_path = None):
     else:
         anomaly_dict[anomaly_code]["list"].append(frame_id)
 
+
 # Custom warning format cuz the default one is wayyyyyy too verbose
-def custom_warning_format(message, category, filename, lineno, line=None):
+def custom_warning_format(message, category, filename, lineno, line = None):
     return f"WARNING : {message}\n"
+
 
 warnings.formatwarning = custom_warning_format
 
+
 # ============================== Helper functions ============================== #
+
 
 def normalizeCoords(line, width, height):
     """
@@ -643,6 +669,7 @@ if __name__ == "__main__":
                         break
 
     # Save master data
+    rounded_data_master = round_floats(data_master)
     with open(os.path.join(output_dir, "drivable_path.json"), "w") as f:
         json.dump(data_master, f, indent = 4)
 

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -273,7 +273,7 @@ def getDrivablePath(
 
 def annotateGT(
         raw_img, anno_entry,
-        raw_dir, visualization_dir, mask_dir,
+        raw_dir, visualization_dir,
         init_img_width, init_img_height,
         normalized = True,
         resize = None,
@@ -283,7 +283,6 @@ def annotateGT(
     Annotates and saves an image with:
         - Raw image, in "output_dir/image".
         - Annotated image with all lanes, in "output_dir/visualization".
-        - Binary segmentation mask of drivable path, in "output_dir/segmentation".
     """
 
     # Define save name
@@ -355,12 +354,6 @@ def annotateGT(
 
     # Save visualization img, same format with raw, just different dir, and jpg since it's vis 
     raw_img.save(os.path.join(visualization_dir, save_name.replace("png", "jpg")))
-
-    # Working on binary mask
-    mask = Image.new("L", (new_img_width, new_img_height), 0)
-    mask_draw = ImageDraw.Draw(mask)
-    mask_draw.line(drivable_renormed, fill = 255, width = lane_w)
-    mask.save(os.path.join(mask_dir, save_name))
 
 
 def parseAnnotations(
@@ -583,11 +576,14 @@ if __name__ == "__main__":
     """
     --output_dir
         |----image
-        |----segmentation
         |----visualization
         |----drivable_path.json
     """
-    list_subdirs = ["image", "segmentation", "visualization"]
+    list_subdirs = [
+        "image", 
+        # "segmentation",   # Removed on 2025/06/05 
+        "visualization"
+    ]
     if (os.path.exists(output_dir)):
         warnings.warn(f"Output directory {output_dir} already exists. Purged")
         shutil.rmtree(output_dir)
@@ -648,7 +644,6 @@ if __name__ == "__main__":
                         anno_entry = this_data,
                         raw_dir = os.path.join(output_dir, "image"),
                         visualization_dir = os.path.join(output_dir, "visualization"),
-                        mask_dir = os.path.join(output_dir, "segmentation"),
                         init_img_height = img_height,
                         init_img_width = img_width,
                         resize = resize,

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -525,8 +525,8 @@ if __name__ == "__main__":
 
     # ====== Heuristic boundaries of drivable path for automatic auditing ====== #
 
-    LEFT_ANCHOR_BOUNDARY = RIGHT_ANCHOR_BOUNDARY = 0.2
-    HEIGHT_BOUNDARY = 0.15
+    LEFT_ANCHOR_BOUNDARY = RIGHT_ANCHOR_BOUNDARY = 0.35
+    HEIGHT_BOUNDARY = 0.3
     ANGLE_BOUNDARY = 30
 
     # ============================== Parsing args ============================== #


### PR DESCRIPTION
Addressing #90 . 

## Overview

This script processes annotated CurveLanes dataset frames to generate a bird-eyes view (BEV) representation of the drivable path. It reads per-frame image and lane data, computes the BEV transform using ego-lane boundaries, projects the drivable path into BEV space, and saves both the transformed images and path data for downstream use (training, visualization, etc.).

Algorithm explained in [the slides](https://docs.google.com/presentation/d/1ydEmoYpOctrjI6D9pQssO03jIsPn2LZw/edit?usp=sharing&ouid=112065704205158821324&rtpof=true&sd=true), currently in pages 51-57.

## Usage

### 1. Args

- `--dataset_dir` : path to **processed** CurveLane dataset directory, including `image`, `visualization` and `drivable_path.json`.
- `--early_stopping` : optional. For debugging purpose. Force the process to halt upon reaching a certain amount of images.

## 2. Execute

```bash
# `pov_datasets` includes `CURVELANES` which is the processed CurveLanes directory in this case
# Process first 100 images, then stop (for a quick run, instead of going through ~100k processed images)
python3 EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py --dataset_dir ../pov_datasets/CURVELANES --early_stopping 100
```

The script will add 2 more dirs and one JSON file into the processed CurveLanes directory:
- `image_bev` : transformed BEV image, will be used for main training tasks.
- `visualization_bev` : transformed BEV image with overlayed BEV egopath groundtruths, for data auditting.
- `drivable_path_bev.json` : groundtruth data of egopath in BEV space, structure below:

```json
{
  "000000": [
    [0.499418, 1.0, true],
    [0.505037, 0.96875, true],
    [0.510747, 0.9375, true],
    [0.516551, 0.90625, true],
    [0.522446, 0.875, true],
    [0.528435, 0.84375, true],
    [0.534515, 0.8125, true],
    [0.540688, 0.78125, true],
    [0.546953, 0.75, true],
    [0.553311, 0.71875, true],
    [0.559761, 0.6875, true],
    [0.566304, 0.65625, true],
    [0.572938, 0.625, true],
    [0.579666, 0.59375, true],
    [0.586485, 0.5625, true],
    [0.593398, 0.53125, true],
    [0.600402, 0.5, true],
    [0.607499, 0.46875, true],
    [0.614688, 0.4375, true],
    [0.62197, 0.40625, true],
    [0.629344, 0.375, true],
    [0.63681, 0.34375, true],
    [0.644369, 0.3125, true],
    [0.652021, 0.28125, true],
    [0.659764, 0.25, true],
    [0.6676, 0.21875, true],
    [0.675529, 0.1875, true],
    [0.68355, 0.15625, true],
    [0.691663, 0.125, true],
    [0.699869, 0.09375, true],
    [0.708167, 0.0625, true],
    [0.716557, 0.03125, true],
    [0.72504, 0.0, true]
  ],
  "000001": [
  ......
  ],
......
}
```

You can see that, each frame ID key maps to the BEV egopath groundtruth, which is a list of exactly 33 BEV egopath points: `[x, y, flag]`, where `x` and `y` are normalized coordinates of the points, and `flag` is to tell if the point is INSIDE the BEV perspective or not. These points are sorted in decreasing `y`, and each adjacent pair of `y` values are `0.03125`, or `20` pixels, diff.

## III. Functions

All associated functions are described in the `README.MD` file of CurveLanes EgoPath module.