### PR TITLE
[Hotfix] BEV parsing script

### DIFF
--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -172,27 +172,29 @@ def findSourcePointsBEV(
     sps["LS"] = [anchor_left[0], h]
     sps["RS"] = [anchor_right[0], h]
 
-    # Deal with cases when either of 2 egolines are vertical
-    # In these cases, anchor = (x0, None, None)
-    if (not anchor_left[1] or not anchor_right[1]):
-        return None
-
     # CALCULATING LE AND RE BASED ON LATEST ALGORITHM
 
     midanchor_start = [(sps["LS"][0] + sps["RS"][0]) / 2, h]
-    left_deg = 90 if not anchor_left[1] else math.degrees(math.atan(anchor_left[1])) % 180
-    right_deg = 90 if not anchor_right[1] else math.degrees(math.atan(anchor_right[1])) % 180
-    mid_deg = (left_deg + right_deg) / 2
-    mid_grad = - math.tan(math.radians(mid_deg))
-    mid_intercept = h - mid_grad * midanchor_start[0]
-
     ego_height = max(egoleft[-1][1], egoright[-1][1]) * 1.05
     print(f"egoheight = {ego_height} with egoleft[-1][1] = {egoleft[-1][1]} and egoright[-1][1] = {egoright[-1][1]}")
-    midanchor_end = [
-        (ego_height - mid_intercept) / mid_grad,
-        ego_height
-    ]
-    original_end_w = interpX(egoright, ego_height) - interpX(egoleft, ego_height)
+
+    # Both egos have Null anchors
+    if ((not anchor_left[1]) and (not anchor_right[1])):
+        midanchor_end = [midanchor_start[0], h]
+        original_end_w = sps["RS"][0] - sps["LS"][0]
+
+    else:
+        left_deg = 90 if (not anchor_left[1]) else math.degrees(math.atan(anchor_left[1])) % 180
+        right_deg = 90 if (not anchor_right[1]) else math.degrees(math.atan(anchor_right[1])) % 180
+        mid_deg = (left_deg + right_deg) / 2
+        mid_grad = - math.tan(math.radians(mid_deg))
+        mid_intercept = h - mid_grad * midanchor_start[0]
+        midanchor_end = [
+            (ego_height - mid_intercept) / mid_grad,
+            ego_height
+        ]
+        original_end_w = interpX(egoright, ego_height) - interpX(egoleft, ego_height)
+
     sps["LE"] = [
         midanchor_end[0] - original_end_w / 2,
         ego_height

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -180,8 +180,8 @@ def findSourcePointsBEV(
     # CALCULATING LE AND RE BASED ON LATEST ALGORITHM
 
     midanchor_start = [(sps["LS"][0] + sps["RS"][0]) / 2, h]
-    left_deg = math.degrees(math.atan(anchor_left[1])) % 180
-    right_deg = math.degrees(math.atan(anchor_right[1])) % 180
+    left_deg = 90 if not anchor_left[1] else math.degrees(math.atan(anchor_left[1])) % 180
+    right_deg = 90 if not anchor_right[1] else math.degrees(math.atan(anchor_right[1])) % 180
     mid_deg = (left_deg + right_deg) / 2
     mid_grad = - math.tan(math.radians(mid_deg))
     mid_intercept = h - mid_grad * midanchor_start[0]

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -196,7 +196,6 @@ def findSourcePointsBEV(
 
     midanchor_start = [(sps["LS"][0] + sps["RS"][0]) / 2, h]
     ego_height = max(egoleft[-1][1], egoright[-1][1]) * 1.05
-    # print(f"egoheight = {ego_height} with egoleft[-1][1] = {egoleft[-1][1]} and egoright[-1][1] = {egoright[-1][1]}")
 
     # Both egos have Null anchors
     if ((not anchor_left[1]) and (not anchor_right[1])):
@@ -242,12 +241,10 @@ def transformBEV(
     h, w, _ = img.shape
 
     # Renorm/tuplize drivable path
-    # print(egopath)
     egopath = [
         (point[0] * w, point[1] * h) for point in egopath
         if (point[1] * h >= sps["ego_h"])
     ]
-    # print(egopath)
     if (not egopath):
         return (None, None, None, None, None)
 
@@ -385,16 +382,12 @@ if __name__ == "__main__":
     for frame_id, frame_content in json_data.items():
 
         counter += 1
-        # print(frame_id)
 
         # Acquire frame
         frame_img_path = os.path.join(
             IMG_DIR,
             f"{frame_id}.png"
         )
-        # This is for single-frame testing only
-        # if (not os.path.exists(frame_img_path)):
-        #     continue
         img = cv2.imread(frame_img_path)
         h, w, _ = img.shape
 
@@ -450,17 +443,9 @@ if __name__ == "__main__":
                 flag_list,
                 validity_list
             )
-            # bev_egopath = [
-            #     zipped_ent[0]
-            #     for zipped_ent in zipped_path_flag
-            # ]
-            # flag_list = [
-            #     zipped_ent[1]
-            #     for zipped_ent in zipped_path_flag
-            # ]
 
             # Register this frame GT to master JSON
-            # Each point has tuple format (x, y, flag)
+            # Each point has tuple format (x, y, flag, valid)
             data_master[frame_id] = [
                 (point[0], point[1], flag, valid)
                 for point, flag, valid in list(zip(bev_egopath, flag_list, validity_list))

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -172,6 +172,11 @@ def findSourcePointsBEV(
     sps["LS"] = [anchor_left[0], h]
     sps["RS"] = [anchor_right[0], h]
 
+    # Deal with cases when either of 2 egolines are vertical
+    # In these cases, anchor = (x0, None, None)
+    if (not anchor_left[1] or not anchor_right[1]):
+        return None
+
     # CALCULATING LE AND RE BASED ON LATEST ALGORITHM
 
     midanchor_start = [(sps["LS"][0] + sps["RS"][0]) / 2, h]

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -187,6 +187,7 @@ def findSourcePointsBEV(
     mid_intercept = h - mid_grad * midanchor_start[0]
 
     ego_height = max(egoleft[-1][1], egoright[-1][1]) * 1.05
+    print(f"egoheight = {ego_height} with egoleft[-1][1] = {egoleft[-1][1]} and egoright[-1][1] = {egoright[-1][1]}")
     midanchor_end = [
         (ego_height - mid_intercept) / mid_grad,
         ego_height
@@ -219,10 +220,12 @@ def transformBEV(
     h, w, _ = img.shape
 
     # Renorm/tuplize drivable path
+    print(egopath)
     egopath = [
         (point[0] * w, point[1] * h) for point in egopath
         if (point[1] * h >= sps["ego_h"])
     ]
+    print(egopath)
 
     # Interp more points for original egopath
     egopath = interpLine(egopath, MIN_POINTS)
@@ -356,6 +359,7 @@ if __name__ == "__main__":
     for frame_id, frame_content in json_data.items():
 
         counter += 1
+        print(frame_id)
 
         # Acquire frame
         frame_img_path = os.path.join(
@@ -375,9 +379,11 @@ if __name__ == "__main__":
             egoleft = this_frame_data["egoleft_lane"],
             egoright = this_frame_data["egoright_lane"]
         )
+        print(sps_dict)
 
         # Skip if invalid frame (due to vertical egolines)
         if (not sps_dict):
+            print(f"Skipped frame ID = {frame_id} due to vertical egoline.")
             continue
 
         # Transform to BEV space

--- a/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
+++ b/EgoPath/create_path/CurveLanes/parse_curvelanes_bev.py
@@ -376,6 +376,10 @@ if __name__ == "__main__":
             egoright = this_frame_data["egoright_lane"]
         )
 
+        # Skip if invalid frame (due to vertical egolines)
+        if (not sps_dict):
+            continue
+
         # Transform to BEV space
         im_dst, bev_egopath, flag_list, mat = transformBEV(
             img = img,


### PR DESCRIPTION
Current CurveLane BEV parsing script doesn't take into account frames with vertical egolines. These cases are primarily caused by egolines with too few points. Previous EgoPath pipeline has threshold conditions to keep these cases at bay, but since we get rid of them in this new BEV version, those cases obviously came back.

This hotfix allows the script to ignore those frames.