### PR TITLE
[Hotfix] CurveLane pipeline - Sort lines by Y-coords, removing all heuristic thresholds

### DIFF
--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -104,7 +104,7 @@ def getLineAnchor(line, new_img_height):
     return (x0, a, b)
 
 
-def getEgoIndexes(frame_id, anchors, new_img_width):
+def getEgoIndexes(anchors, new_img_width):
     """
     Identifies 2 ego lanes - left and right - from a sorted list of line anchors.
     """
@@ -318,7 +318,7 @@ def parseAnnotations(
     with open(anno_path, "r") as f:
         read_data = json.load(f)["Lines"]
         if (len(read_data) < 2):    # Some files are empty, or having less than 2 lines
-            warnings.warn(f"Parsing {anno_path} : insufficient line amount: {len(read_data)}")
+            warnings.warn(f"Parsing {anno_path} : insufficient line amount: {len(read_data)} in raw data. Skipping this frame.")
             return None
         else:
             # Parse data from those JSON lines, also sort by y
@@ -367,7 +367,7 @@ def parseAnnotations(
             # Remove empty lanes
             lines = [line for line in lines if (line and len(line) >= 2)]   # Pick lines with >= 2 points
             if (len(lines) < 2):    # Ignore frames with less than 2 lines
-                warnings.warn(f"Parsing {anno_path}: insufficient line amount after cropping: {len(lines)}")
+                warnings.warn(f"Parsing {anno_path}: insufficient line amount after cropping: {len(lines)}. Skipping this frame.")
                 return None
             
             # Determine 2 ego lines via line anchors

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -369,7 +369,7 @@ def parseAnnotations(
         else:
             # Parse data from those JSON lines, also sort by y
             lines = [
-                [(float(point["x"]), float(point["y"])) for point in line].sort(
+                sorted([(float(point["x"]), float(point["y"])) for point in line],
                     key = lambda x: x[1], 
                     reverse = True
                 )

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -10,26 +10,6 @@ import numpy as np
 from PIL import Image, ImageDraw
 
 
-anomaly_dict = {
-    "one-sided-anchors" : {
-        "count" : 0,
-        "list" : []
-    },
-    "non-mid-egopath" : {
-        "count" : 0,
-        "list" : {}
-    },
-    "too-short-egopath" : {
-        "count" : 0,
-        "list" : {}
-    },
-    "too-steep-egopath" : {
-        "count" : 0,
-        "list" : {}
-    },
-}
-
-
 # ============================= Format functions ============================= #
 
 
@@ -42,14 +22,6 @@ def round_line_floats(line, ndigits = 6):
         ]
     line = tuple(line)
     return line
-
-
-def add_anomaly(frame_id, anomaly_code, drivable_path = None):
-    anomaly_dict[anomaly_code]["count"] += 1
-    if (drivable_path):
-        anomaly_dict[anomaly_code]["list"][frame_id] = drivable_path
-    else:
-        anomaly_dict[anomaly_code]["list"].append(frame_id)
 
 
 # Custom warning format cuz the default one is wayyyyyy too verbose
@@ -139,13 +111,13 @@ def getEgoIndexes(frame_id, anchors, new_img_width):
     for i in range(len(anchors)):
         if (anchors[i][0] >= new_img_width / 2):
             if (i == 0):
-                add_anomaly(frame_id, "one-sided-anchors")
-                return "NO LINES on the LEFT side of frame. Something's sussy out there!"
-            left_ego_idx, right_ego_idx = i - 1, i
-            return (left_ego_idx, right_ego_idx)
-        
-    add_anomaly(frame_id, "one-sided-anchors")
-    return "NO LINES on the RIGHT side of frame. Something's sussy out there!"
+                print("NO LINES on the LEFT side of frame. Registering FIRST 2 lines on the right side as egolines.")
+                return (i, i + 1)
+            
+            return (i - 1, i)
+    
+    print("NO LINES on the RIGHT side of frame. Registering LAST 2 lines on the left side as egolines.")
+    return (-2, -1)
 
 
 def getDrivablePath(

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -415,7 +415,6 @@ def parseAnnotations(
             ]
 
             ego_indexes = getEgoIndexes(
-                frame_id,
                 [anchor[1] for anchor in line_anchors],
                 new_img_width
             )

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -149,9 +149,8 @@ def getEgoIndexes(frame_id, anchors, new_img_width):
 
 
 def getDrivablePath(
-        frame_id,
         left_ego, right_ego, 
-        new_img_height, new_img_width, 
+        new_img_height,
         y_coords_interp = False
 ):
     """
@@ -243,23 +242,6 @@ def getDrivablePath(
                     x_top = x1 + (y_top - y1) / a
 
                 drivable_path.append((x_top, y_top))
-
-    # Now check drivable path's params for automatic auditting
-
-    drivable_path_angle_deg = math.degrees(math.atan(float(
-        abs(drivable_path[-1][1] - drivable_path[0][1]) / \
-        abs(drivable_path[-1][0] - drivable_path[0][0])
-    )))
-
-    if not (new_img_width * LEFT_ANCHOR_BOUNDARY <= drivable_path[0][0] <= new_img_width * (1 - RIGHT_ANCHOR_BOUNDARY)):
-        add_anomaly(frame_id, "non-mid-egopath", drivable_path)
-        return f"Drivable path has anchor point out of heuristic boundary [{LEFT_ANCHOR_BOUNDARY} , {1 - RIGHT_ANCHOR_BOUNDARY}], ignoring this frame!"
-    elif not (drivable_path[-1][1] < new_img_height * (1 - HEIGHT_BOUNDARY)):
-        add_anomaly(frame_id, "too-short-egopath", drivable_path)
-        return f"Drivable path has length not exceeding heuristic length of {HEIGHT_BOUNDARY * 100}% frame height, ignoring this frame!"
-    elif not (drivable_path_angle_deg >= ANGLE_BOUNDARY):
-        add_anomaly(frame_id, "too-steep-egopath", drivable_path)
-        return f"Drivable path has angle not exceeding heuristic angle of {ANGLE_BOUNDARY} degrees, ignoring this frame!"
 
     return drivable_path
 
@@ -512,12 +494,6 @@ if __name__ == "__main__":
     # For interping lines with soooooooo few points, 2~3 or so
     LINE_INTERP_THRESHOLD = 5
 
-    # ====== Heuristic boundaries of drivable path for automatic auditing ====== #
-
-    LEFT_ANCHOR_BOUNDARY = RIGHT_ANCHOR_BOUNDARY = 0.25
-    HEIGHT_BOUNDARY = 0.15
-    ANGLE_BOUNDARY = 30
-
     # ============================== Parsing args ============================== #
 
     parser = argparse.ArgumentParser(
@@ -662,7 +638,3 @@ if __name__ == "__main__":
     # Save master data
     with open(os.path.join(output_dir, "drivable_path.json"), "w") as f:
         json.dump(data_master, f, indent = 4)
-
-    # Save discarded data
-    with open(os.path.join(output_dir, "anomaly.json"), "w") as f:
-        json.dump(anomaly_dict, f, indent = 4)

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -429,9 +429,8 @@ def parseAnnotations(
 
             # Determine drivable path from 2 egos, and switch on interp cuz this is CurveLanes
             drivable_path = getDrivablePath(
-                frame_id,
                 left_ego, right_ego,
-                new_img_height, new_img_width,
+                new_img_height,
                 y_coords_interp = True
             )
 

--- a/EgoPath/create_path/CurveLanes/process_curvelanes.py
+++ b/EgoPath/create_path/CurveLanes/process_curvelanes.py
@@ -367,9 +367,12 @@ def parseAnnotations(
             warnings.warn(f"Parsing {anno_path} : insufficient line amount: {len(read_data)}")
             return None
         else:
-            # Parse data from those JSON lines
+            # Parse data from those JSON lines, also sort by y
             lines = [
-                [(float(point["x"]), float(point["y"])) for point in line]
+                [(float(point["x"]), float(point["y"])) for point in line].sort(
+                    key = lambda x: x[1], 
+                    reverse = True
+                )
                 for line in read_data
             ]
 


### PR DESCRIPTION
Previously we assumed the lines in CurveLanes dataset were already sorted by decreasing `y` coords, meaning all lines are annotated bottom-up.

However this rule sometimes isn't applied for some frames, thus wreaking havocs on downstream tasks.

For example, processed frame `001013`:

```json
"egoright_lane": [
            [
                0.29761250000000006,
                0.79845
            ],
            [
                0.3569,
                0.8189
            ],
            [
                0.44685,
                0.8781749999999999
            ],
            [
                0.5459999999999999,
                0.9660749999999999
            ]
        ],
```

![image](https://github.com/user-attachments/assets/5671b169-8d04-4f54-87f9-463460a60867)

This hotfix ensures all lines will be sorted by Y coords beforehand.