### PR TITLE
[AutoSteer] CULane BEV parsing module

### DIFF
--- a/EgoPath/create_path/CULane/README.md
+++ b/EgoPath/create_path/CULane/README.md
@@ -238,7 +238,7 @@ python process_culane.py --dataset_dir /path/to/CULane --output_dir /path/to/out
 
 ### Usage
 
-### Outputs
+#### Outputs
 
 ```bash
 --output_dir

--- a/EgoPath/create_path/CULane/README.md
+++ b/EgoPath/create_path/CULane/README.md
@@ -83,3 +83,6 @@ CULane is a large-scale lane detection dataset specifically designed for autonom
 
 ```bash
 python process_culane.py --dataset_dir /path/to/CULane --output_dir /path/to/output
+
+python3 EgoPath/create_path/CULane/process_culane.py --dataset_dir ../pov_datasets/CULane --output_dir ../pov_datasets/CULANE
+python3 EgoPath/create_path/CULane/parse_culane_bev.py --dataset_dir ../pov_datasets/CULANE/

--- a/EgoPath/create_path/CULane/README.md
+++ b/EgoPath/create_path/CULane/README.md
@@ -2,15 +2,24 @@
 
 ## Overview
 
-CULane is a large-scale lane detection dataset specifically designed for autonomous driving research. It consists of images captured from a car-mounted camera moving in Beijing, China, under various real-world scenarios, including urban traffic, highways, and challenging weather conditions. This script processes the CULane dataset to generate normalized annotations, drivable paths, and segmentation masks for lane detection tasks.
+CULane is a large-scale lane detection dataset specifically designed for autonomous driving research. It consists of images captured from a car-mounted camera moving in Beijing, China, under various real-world scenarios, including urban traffic, highways, and challenging weather conditions. This script processes the CULane dataset to generate normalized annotations, drivable paths, and segmentation masks for lane detection tasks. Basically, these scripts produce:
+
+- Normalized lane annotations
+- Ego lane identification (left and right)
+- Drivable path computation
+- Visualization outputs
+- Polyfitted BEV projections
+- Reprojected lane visualizations
 
 ![alt text](../../../Media/CULane_dataset_preview.png)
 
 ---
 
-## Functions
+## 1. CULane raw dataset processing (`process_culane.py`)
 
-### `normalizeCoords(lane, width, height)`
+### Functions
+
+#### `normalizeCoords(lane, width, height)`
 - **Description**: normalizes lane coordinates to a scale of `[0, 1]` based on image dimensions.
 - **Parameters**:
   - `lane` (list of tuples): list of `(x, y)` points defining a lane.
@@ -18,50 +27,44 @@ CULane is a large-scale lane detection dataset specifically designed for autonom
   - `height` (int): height of the image.
 - **Returns**: a list of normalized `(x, y)` points.
 
----
 
-### `getLaneAnchor(lane)`
+#### `getLaneAnchor(lane)`
 - **Description**: determines the "anchor" point of a lane, which is used to identify ego lanes.
 - **Parameters**:
   - `lane` (list of tuples): list of `(x, y)` points defining a lane.
 - **Returns**: a tuple containing the anchor `(x0, a, b)` for the lane, where `x0` is the x-coordinate at the bottom of the frame, and `(a, b)` are slope and intercept of the lane equation.
 
----
 
-### `getEgoIndexes(anchors)`
+#### `getEgoIndexes(anchors)`
 - **Description**: identifies the left and right ego lanes from a list of lane anchors.
 - **Parameters**:
   - `anchors` (list of tuples): list of lane anchors.
 - **Returns**: a tuple `(left_ego_idx, right_ego_idx)` of the indexes of the two ego lanes, or a warning message if insufficient lanes are detected.
 
----
 
-### `getDrivablePath(left_ego, right_ego)`
+#### `getDrivablePath(left_ego, right_ego)`
 - **Description**: computes the drivable path as the midpoint between the two ego lanes.
 - **Parameters**:
   - `left_ego` (list of tuples): points defining the left ego lane.
   - `right_ego` (list of tuples): points defining the right ego lane.
 - **Returns**: a list of `(x, y)` points representing the drivable path.
 
----
 
-### `annotateGT(anno_entry, anno_raw_file, raw_dir, visualization_dir, mask_dir, img_width, img_height, normalized=True, crop=None)`
+#### `annotateGT(anno_entry, anno_raw_file, raw_dir, visualization_dir, mask_dir, img_width, img_height, normalized=True, crop=None)`
 - **Description**: annotates and saves images with lanes, drivable paths, and binary masks.
 - **Parameters**:
   - `anno_entry` (dict): normalized annotation data.
   - `anno_raw_file` (str): path to the raw image file.
   - `raw_dir` (str): directory for saving raw images.
   - `visualization_dir` (str): directory for saving annotated images.
-  - `mask_dir` (str): directory for saving binary masks.
   - `img_width` (int): width of the processed image.
   - `img_height` (int): height of the processed image.
   - `normalized` (bool): if `True`, annotations are normalized.
   - `crop` (dict): Crop dimensions in the format `{"TOP": int, "RIGHT": int, "BOTTOM": int, "LEFT": int}`.
 - **Returns**: none.
 
----
 
-### `parseAnnotations(anno_path, crop=None)`
+#### `parseAnnotations(anno_path, crop=None)`
 - **Description**: parses lane annotations and extracts normalized ground truth data.
 - **Parameters**:
   - `anno_path` (str): path to the annotation file.
@@ -70,19 +73,211 @@ CULane is a large-scale lane detection dataset specifically designed for autonom
 
 ---
 
-## Usage
+### Usage
 
-### Args
+#### Args
 - `--dataset_dir`: path to the CULane dataset directory.
 - `--output_dir`: path to the directory where processed outputs will be saved.
 - `--crop`: optional. Crop dimensions as `[TOP, RIGHT, BOTTOM, LEFT]`. Default is `[0, 390, 160, 390]`.
 - `--sampling_step`: optional. Sampling step for each split/class. Default is `5`.
 - `--early_stopping`: optional. Stops after processing a specific number of files for debugging purposes.
 
-## Running the script
+---
+
+### Outputs
+
+```bash
+--output_dir
+    ├── image/                # Cropped raw images
+    ├── visualization/        # Raw image with lane/path overlays
+    └── drivable_path.json    # Normalized annotation data
+```
+
+---
+
+### Running the script
 
 ```bash
 python process_culane.py --dataset_dir /path/to/CULane --output_dir /path/to/output
+```
 
+---
+
+## 2. CULane raw dataset processing (`parse_culane_bev.py`)
+
+### Functions
+
+
+#### `log_skipped(frame_id, reason)`
+
+- **Description**: Records skipped frame IDs and reasons into a global dictionary for later reporting.
+- **Parameters**:
+  - `frame_id` (str): identifier of the frame being skipped.
+  - `reason` (str): explanation for skipping the frame.
+- **Returns**: None
+
+
+#### `imagePointTuplize(point)`
+
+- **Description**: converts a floating-point `(x, y)` coordinate into integer pixel coordinates for image drawing or indexing.
+- **Parameters**:
+  - `point` (tuple): floating-point coordinate `(x, y)`.
+- **Returns**: integer coordinate `(x, y)`.
+
+
+#### `roundLineFloats(line, ndigits=4)`
+
+- **Description**: rounds each point in a line to a given number of decimal places.
+- **Parameters**:
+  - `line` (list): list of `(x, y)` tuples.
+  - `ndigits` (int): number of decimal places to round to. Default is 4.
+- **Returns**: rounded list of `(x, y)` tuples.
+
+
+#### `normalizeCoords(line, width, height)`
+
+- **Description**: normalizes coordinates to the `[0, 1]` range using image dimensions.
+- **Parameters**:
+  - `line` (list): list of `(x, y)` tuples.
+  - `width` (int): image width.
+  - `height` (int): image height.
+- **Returns**: normalized list of `(x, y)` tuples.
+
+
+#### `interpLine(line, points_quota)`
+
+- **Description**: interpolates additional points along a line based on arc length to meet a minimum quota.
+- **Parameters**:
+  - `line` (list): list of `(x, y)` tuples.
+  - `points_quota` (int): required minimum number of points.
+- **Returns**: interpolated list of `(x, y)` tuples.
+
+
+#### `getLineAnchor(line)`
+
+- **Description**: computes an anchor `(x0, a, b)` representing the lane's intercept and slope at the bottom of the image. Warns on vertical or horizontal lanes.
+- **Parameters**:
+  - `line` (list): list of `(x, y)` tuples.
+- **Returns**: tuple `(x0, a, b)` where `x0` is the intercept, and `a`, `b` are slope and intercept.
+
+
+#### `drawLine(img, line, color, thickness=2)`
+
+- **Description**: draws a polyline on an image using OpenCV.
+- **Parameters**:
+  - `img` (ndarray): target image.
+  - `line` (list): list of `(x, y)` tuples.
+  - `color` (tuple): BGR color.
+  - `thickness` (int): line thickness. Default is 2.
+- **Returns**: none
+
+
+#### `annotateGT(img, orig_img, frame_id, bev_egopath, reproj_egopath, bev_egoleft, reproj_egoleft, bev_egoright, reproj_egoright, raw_dir, visualization_dir, normalized)`
+
+- **Description**: annotates and saves both BEV-space and original-space visualizations of ego lanes and drivable path.
+- **Parameters**:
+  - `img` (ndarray): BEV image.
+  - `orig_img` (ndarray): original image.
+  - `frame_id` (str): image ID used for saving.
+  - `bev_egopath`, `bev_egoleft`, `bev_egoright` (list): BEV-space lines.
+  - `reproj_egopath`, `reproj_egoleft`, `reproj_egoright` (list): reprojected lines.
+  - `raw_dir` (str): directory for BEV raw images.
+  - `visualization_dir` (str): directory for visualizations.
+  - `normalized` (bool): whether coordinates are normalized.
+- **Returns**: none
+
+
+#### `interpX(line, y)`
+
+- **Description**: interpolates the x-coordinate along a lane line at a given y-value.
+- **Parameters**:
+  - `line` (list): list of `(x, y)` tuples.
+  - `y` (float): target y-value.
+- **Returns**: interpolated x-value (float).
+
+
+#### `polyfit_BEV(bev_line, order, y_step, y_limit)`
+
+- **Description**: fits a polynomial to a BEV lane and samples points at regular y-intervals.
+- **Parameters**:
+  - `bev_line` (list): list of `(x, y)` tuples in BEV space.
+  - `order` (int): polynomial degree.
+  - `y_step` (int): y-interval for sampling.
+  - `y_limit` (int): max y-value.
+- **Returns**: tuple `(fitted_line, flag_list, validity_list)`.
+
+
+#### `findSourcePointsBEV(h, w, egoleft, egoright)`
+
+- **Description**: computes the 4 source points for homography (left/right ego start/end) and ego bottom height.
+- **Parameters**:
+  - `h` (int): image height.
+  - `w` (int): image width.
+  - `egoleft` (list): left ego lane (normalized).
+  - `egoright` (list): right ego lane (normalized).
+- **Returns**: dictionary of source points and ego height.
+
+
+#### `transformBEV(img, line, sps)`
+
+- **Description**: transforms a line to BEV space, fits a polyline, and reprojects it back to the original space.
+- **Parameters**:
+  - `img` (ndarray): input image.
+  - `line` (list): normalized line to transform.
+  - `sps` (dict): source points for homography.
+- **Returns**: tuple:
+  - `im_dst`: warped BEV image,
+  - `bev_line`: fitted BEV line,
+  - `reproj_line`: reprojected original-space line,
+  - `flag_list`: polyfit flags,
+  - `validity_list`: point validity,
+  - `mat`: homography matrix,
+  - `success`: transformation success flag.
+
+---
+
+### Usage
+
+### Outputs
+
+```bash
+--output_dir
+    ├── image_bev/            # BEV-transformed images
+    ├── visualization_bev/    # BEV + reprojected visualization
+    ├── drivable_path_bev.json   # Polyfitted BEV + reprojected annotations
+    └── skipped_frames.json      # Log of skipped frames with reasons
+```
+
+#### Args
+
+- `--dataset_dir` (required)
+  - Path to the processed CULane dataset directory (i.e., the output directory from `process_culane.py`).
+  - Example : `../pov_datasets/CULANE`
+
+- `--early_stopping` (optional)
+  - Limits the number of frames processed. Useful for debugging or quick testing, default `None` (processes all frames).
+  - Example : `--early_stopping 100`
+
+#### Running the script
+
+Once you have processed the CULane dataset using `process_culane.py`, you can run the BEV transformation script to generate BEV views and reprojected visualizations.
+
+```bash
+python3 EgoPath/create_path/CULane/parse_culane_bev.py \
+  --dataset_dir ../pov_datasets/CULANE
+```
+
+You can limit the number of frames for debugging or development purposes. This will process first 100 frames.
+
+```bash
+python3 EgoPath/create_path/CULane/parse_culane_bev.py \
+  --dataset_dir ../pov_datasets/CULANE \
+  --early_stopping 100
+```
+
+## 3. End-to-end run
+
+```bash
 python3 EgoPath/create_path/CULane/process_culane.py --dataset_dir ../pov_datasets/CULane --output_dir ../pov_datasets/CULANE
 python3 EgoPath/create_path/CULane/parse_culane_bev.py --dataset_dir ../pov_datasets/CULANE/
+```

--- a/EgoPath/create_path/CULane/parse_culane_bev.py
+++ b/EgoPath/create_path/CULane/parse_culane_bev.py
@@ -122,3 +122,165 @@ def getLineAnchor(line):
     return (x0, a, b)
 
 
+def drawLine(
+    img: np.ndarray, 
+    line: list,
+    color: tuple,
+    thickness: int = 2
+):
+    for i in range(1, len(line)):
+        pt1 = (
+            int(line[i - 1][0]), 
+            int(line[i - 1][1])
+        )
+        pt2 = (
+            int(line[i][0]), 
+            int(line[i][1])
+        )
+        cv2.line(
+            img, 
+            pt1, pt2, 
+            color = color, 
+            thickness = thickness
+        )
+
+
+def annotateGT(
+    img: np.ndarray,
+    orig_img: np.ndarray,
+    frame_id: str,
+    bev_egopath: list,
+    reproj_egopath: list,
+    bev_egoleft: list,
+    reproj_egoleft: list,
+    bev_egoright: list,
+    reproj_egoright: list,
+    raw_dir: str, 
+    visualization_dir: str,
+    normalized: bool
+):
+    """
+    Annotates and saves an image with:
+        - Raw image, in "output_dir/image".
+        - Annotated image with all lanes, in "output_dir/visualization".
+    """
+
+    # =========================== RAW IMAGE =========================== #
+
+    # Save raw img in raw dir, as PNG
+    cv2.imwrite(
+        os.path.join(
+            raw_dir,
+            f"{frame_id}.png"
+        ),
+        img
+    )
+
+    # =========================== BEV VIS =========================== #
+
+    img_bev_vis = img.copy()
+    h, w, _ = img_bev_vis.shape
+
+    # Draw egopath
+    if (normalized):
+        renormed_bev_egopath = [
+            (x * w, y * h) 
+            for x, y in bev_egopath
+        ]
+    else:
+        renormed_bev_egopath = bev_egopath
+    drawLine(
+        img = img_bev_vis,
+        line = renormed_bev_egopath,
+        color = COLOR_EGOPATH
+    )
+    
+    # Draw egoleft
+    if (normalized):
+        renormed_bev_egoleft = [
+            (x * w, y * h) 
+            for x, y in bev_egoleft
+        ]
+    else:
+        renormed_bev_egoleft = bev_egoleft
+    drawLine(
+        img = img_bev_vis,
+        line = renormed_bev_egoleft,
+        color = COLOR_EGOLEFT
+    )
+
+    # Draw egoright
+    if (normalized):
+        renormed_bev_egoright = [
+            (x * w, y * h) 
+            for x, y in bev_egoright
+        ]
+    else:
+        renormed_bev_egoright = bev_egoright
+    drawLine(
+        img = img_bev_vis,
+        line = renormed_bev_egoright,
+        color = COLOR_EGORIGHT
+    )
+
+    # Save visualization img in vis dir, as JPG (saving storage space)
+    cv2.imwrite(
+        os.path.join(
+            visualization_dir,
+            f"{frame_id}.jpg"
+        ),
+        img_bev_vis
+    )
+
+    # =========================== ORIGINAL VIS =========================== #
+
+    # Draw reprojected egopath
+    if (normalized):
+        renormed_reproj_egopath = [
+            (x * w, y * h) 
+            for x, y in reproj_egopath
+        ]
+    else:
+        renormed_reproj_egopath = reproj_egopath
+    drawLine(
+        img = orig_img,
+        line = renormed_reproj_egopath,
+        color = COLOR_EGOPATH
+    )
+    
+    # Draw reprojected egoleft
+    if (normalized):
+        renormed_reproj_egoleft = [
+            (x * w, y * h) 
+            for x, y in reproj_egoleft
+        ]
+    else:
+        renormed_reproj_egoleft = reproj_egoleft
+    drawLine(
+        img = orig_img,
+        line = renormed_reproj_egoleft,
+        color = COLOR_EGOLEFT
+    )
+
+    # Draw reprojected egoright
+    if (normalized):
+        renormed_reproj_egoright = [
+            (x * w, y * h) 
+            for x, y in reproj_egoright
+        ]
+    else:
+        renormed_reproj_egoright = reproj_egoright
+    drawLine(
+        img = orig_img,
+        line = renormed_reproj_egoright,
+        color = COLOR_EGORIGHT
+    )
+
+    # Save it
+    cv2.imwrite(
+        os.path.join(
+            visualization_dir,
+            f"{frame_id}_orig.jpg"
+        ),
+        orig_img
+    )

--- a/EgoPath/create_path/CULane/parse_culane_bev.py
+++ b/EgoPath/create_path/CULane/parse_culane_bev.py
@@ -48,3 +48,104 @@ def normalizeCoords(lane, width, height):
     ]
 
 
+def getLaneAnchor(lane):
+    """
+    Determine "anchor" point of a lane.
+
+    """
+    (x2, y2) = lane[0]
+    (x1, y1) = lane[1]
+    for i in range(1, len(lane) - 1, 1):
+        if (lane[i][0] != x2):
+            (x1, y1) = lane[i]
+            break
+    if (x1 == x2):
+        warnings.warn(f"Vertical lane detected: {lane}, with these 2 anchors: ({x1}, {y1}), ({x2}, {y2}).")
+        return (x1, None, None)
+    a = (y2 - y1) / (x2 - x1)
+    b = y1 - a * x1
+    x0 = (img_height - b) / a
+    
+    return (x0, a, b)
+
+
+def getEgoIndexes(anchors):
+    """
+    Identifies 2 ego lanes - left and right - from a sorted list of lane anchors.
+
+    """
+    for i in range(len(anchors)):
+        if (anchors[i][0] >= img_width / 2):
+            if (i == 0):
+                return "NO LANES on the LEFT side of frame."
+            left_ego_idx, right_ego_idx = i - 1, i
+            return (left_ego_idx, right_ego_idx)
+    
+    return "NO LANES on the RIGHT side of frame."
+
+
+def getDrivablePath(left_ego, right_ego):
+    """
+    Computes drivable path as midpoint between 2 ego lanes, basically the main point of this task.
+
+    """
+    i, j = 0, 0
+    drivable_path = []
+    while (i <= len(left_ego) - 1 and j <= len(right_ego) - 1):
+        if (left_ego[i][1] == right_ego[j][1]):
+            drivable_path.append((
+                (left_ego[i][0] + right_ego[j][0]) / 2,     # Midpoint along x axis
+                left_ego[i][1]
+            ))
+            i += 1
+            j += 1
+        elif (left_ego[i][1] > right_ego[j][1]):
+            i += 1
+        else:
+            j += 1
+
+    # Extend drivable path to bottom edge of the frame
+    if ((len(drivable_path) >= 2) and (drivable_path[0][1] < img_height)):
+        x1, y1 = drivable_path[1]
+        x2, y2 = drivable_path[0]
+        if (x2 == x1):
+            x_bottom = x2
+        else:
+            a = (y2 - y1) / (x2 - x1)
+            x_bottom = x2 + (img_height - y2) / a
+        drivable_path.insert(0, (x_bottom, img_height))
+
+    # Extend drivable path to be on par with longest ego lane
+    # By making it parallel with longer ego lane
+    y_top = min(left_ego[-1][1], right_ego[-1][1])
+    if ((len(drivable_path) >= 2) and (drivable_path[-1][1] > y_top)):
+        sign_left_ego = left_ego[-1][0] - left_ego[-2][0]
+        sign_right_ego = right_ego[-1][0] - right_ego[-2][0]
+        sign_val = sign_left_ego * sign_right_ego
+        # 2 egos going the same direction
+        if (sign_val > 0):
+            longer_ego = left_ego if left_ego[-1][1] < right_ego[-1][1] else right_ego
+            if len(longer_ego) >= 2 and len(drivable_path) >= 2:
+                x1, y1 = longer_ego[-1]
+                x2, y2 = longer_ego[-2]
+                if (x2 == x1):
+                    x_top = drivable_path[-1][0]
+                else:
+                    a = (y2 - y1) / (x2 - x1)
+                    x_top = drivable_path[-1][0] + (y_top - drivable_path[-1][1]) / a
+
+                drivable_path.append((x_top, y_top))
+        # 2 egos going opposite directions
+        else:
+            if len(drivable_path) >= 2:
+                x1, y1 = drivable_path[-1]
+                x2, y2 = drivable_path[-2]
+                if (x2 == x1):
+                    x_top = x1
+                else:
+                    a = (y2 - y1) / (x2 - x1)
+                    x_top = x1 + (y_top - y1) / a
+
+                drivable_path.append((x_top, y_top))
+
+    return drivable_path

--- a/EgoPath/create_path/CULane/parse_culane_bev.py
+++ b/EgoPath/create_path/CULane/parse_culane_bev.py
@@ -22,3 +22,29 @@ warnings.formatwarning = custom_warning_format
 # ============================== Helper functions ============================== #
 
 
+def roundLineFloats(line, ndigits = 4):
+    """
+    Round floats to reduce JSON size.
+
+    """
+    line = list(line)
+    for i in range(len(line)):
+        line[i] = [
+            round(line[i][0], ndigits),
+            round(line[i][1], ndigits)
+        ]
+    line = tuple(line)
+    return line
+
+
+def normalizeCoords(lane, width, height):
+    """
+    Normalize the coords of lane points.
+
+    """
+    return [
+        (x / width, y / height) 
+        for x, y in lane
+    ]
+
+

--- a/EgoPath/create_path/CULane/parse_culane_bev.py
+++ b/EgoPath/create_path/CULane/parse_culane_bev.py
@@ -642,6 +642,14 @@ if __name__ == "__main__":
             )
             continue
 
+        # Skip if the polyfit goes horribly wrong
+        if not (bev_egoleft[-1][0] <= bev_egopath[-1][0] <= bev_egoright[-1][0]):
+            log_skipped(
+                frame_id,
+                "Polyfit went horribly wrong."
+            )
+            continue
+
         # Save stuffs
         annotateGT(
             img = im_dst,

--- a/EgoPath/create_path/CULane/parse_culane_bev.py
+++ b/EgoPath/create_path/CULane/parse_culane_bev.py
@@ -492,7 +492,7 @@ if __name__ == "__main__":
 
     # OTHER PARAMS
 
-    W = 860
+    W = 1440
     H = 430
 
     # BEV-related
@@ -505,8 +505,8 @@ if __name__ == "__main__":
     }
     BEV_W = 640
     BEV_H = 1280
-    EGO_HEIGHT_RATIO = 1.05
-    BEV_Y_STEP = 128
+    EGO_HEIGHT_RATIO = 1
+    BEV_Y_STEP = 144
     POLYFIT_ORDER = 2
 
     # Visualization (colors in BGR)
@@ -568,7 +568,7 @@ if __name__ == "__main__":
     data_master = {}    # Dumped later
 
     # Get source points for transform
-    STANDARD_FRAME = "001923"
+    STANDARD_FRAME = "000025"
     STANDARD_JSON = json_data[STANDARD_FRAME]
     STANDARD_SPS = findSourcePointsBEV(
         h = H,

--- a/EgoPath/create_path/CULane/parse_culane_bev.py
+++ b/EgoPath/create_path/CULane/parse_culane_bev.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python3
+
+import argparse
+import json
+import os
+import shutil
+import pathlib
+from PIL import Image, ImageDraw
+import warnings
+from datetime import datetime
+
+# Custom warning format
+def custom_warning_format(
+    message, category, filename, 
+    lineno, line = None
+):
+    return f"WARNING : {message}\n"
+
+warnings.formatwarning = custom_warning_format
+
+
+# ============================== Helper functions ============================== #
+
+

--- a/EgoPath/create_path/CULane/process_culane.py
+++ b/EgoPath/create_path/CULane/process_culane.py
@@ -48,7 +48,7 @@ def getLaneAnchor(lane):
             (x1, y1) = lane[i]
             break
     if (x1 == x2):
-        warnings.warn(f"Vertical lane detected: {lane}, with these 2 anchors: ({x1}, {y1}), ({x2}, {y2}).")
+        # warnings.warn(f"Vertical lane detected: {lane}, with these 2 anchors: ({x1}, {y1}), ({x2}, {y2}).")
         return (x1, None, None)
     a = (y2 - y1) / (x2 - x1)
     b = y1 - a * x1
@@ -215,7 +215,7 @@ def parseAnnotations(anno_path, crop = None):
     with open(anno_path, "r") as f:
         read_data = f.readlines()
         if (len(read_data) < 2):    # Some files are empty, or having less than 2 lines
-            warnings.warn(f"Parsing {anno_path} : insufficient lane amount: {len(read_data)}")
+            # warnings.warn(f"Parsing {anno_path} : insufficient lane amount: {len(read_data)}")
             return None
         else:
             # Parse data from those JSON lines
@@ -243,7 +243,7 @@ def parseAnnotations(anno_path, crop = None):
                 # Remove empty lanes
                 lanes = [lane for lane in lanes if (lane and len(lane) >= 2)]   # Pick lanes with >= 2 points
                 if (len(lanes) < 2):    # Ignore frames with less than 2 lanes
-                    warnings.warn(f"Parsing {anno_path}: insufficient lane amount after cropping: {len(lanes)}")
+                    # warnings.warn(f"Parsing {anno_path}: insufficient lane amount after cropping: {len(lanes)}")
                     return None
 
             # Determine 2 ego lanes
@@ -251,8 +251,8 @@ def parseAnnotations(anno_path, crop = None):
             ego_indexes = getEgoIndexes(lane_anchors)
 
             if (type(ego_indexes) is str):
-                if (ego_indexes.startswith("NO")):
-                    warnings.warn(f"Parsing {anno_path}: {ego_indexes}")
+                # if (ego_indexes.startswith("NO")):
+                    # warnings.warn(f"Parsing {anno_path}: {ego_indexes}")
                 return None
 
             left_ego = lanes[ego_indexes[0]]
@@ -464,7 +464,7 @@ if __name__ == "__main__":
                 this_data = parseAnnotations(anno_file, crop)
                 if (this_data is not None):
 
-                    print(f"Processing data in label file {anno_file}.")
+                    # print(f"Processing data in label file {anno_file}.")
                     annotateGT(
                         anno_entry = this_data,
                         anno_raw_file = os.path.join(dataset_dir, img_path),

--- a/EgoPath/create_path/CULane/process_culane.py
+++ b/EgoPath/create_path/CULane/process_culane.py
@@ -470,7 +470,6 @@ if __name__ == "__main__":
                         anno_raw_file = os.path.join(dataset_dir, img_path),
                         raw_dir = os.path.join(output_dir, "image"),
                         visualization_dir = os.path.join(output_dir, "visualization"),
-                        mask_dir = os.path.join(output_dir, "segmentation"),
                         img_height = img_height,
                         img_width = img_width,
                         crop = crop
@@ -478,11 +477,12 @@ if __name__ == "__main__":
 
                     # Save as 6-digit incremental index
                     img_index = str(str(img_id_counter).zfill(6))
-                    data_master[img_index] = {}
-                    data_master[img_index]["drivable_path"] = this_data["drivable_path"]
-                    data_master[img_index]["img_height"] = img_height
-                    data_master[img_index]["img_width"] = img_width
-                    
+                    data_master[img_index] = {
+                        "drivable_path": this_data["drivable_path"],
+                        "egoleft_lane": this_data["egoleft_lane"],
+                        "egoright_lane": this_data["egoright_lane"],
+                    }
+
                     # Early stopping, it defined
                     if (early_stopping and img_id_counter >= early_stopping - 1):
                         break

--- a/EgoPath/create_path/CULane/process_culane.py
+++ b/EgoPath/create_path/CULane/process_culane.py
@@ -314,8 +314,8 @@ if __name__ == "__main__":
     list_path = "list"
     test_classification = "test_split"
 
-    img_width = 1640
-    img_height = 590
+    img_width = 1640        # New width: 1440
+    img_height = 590        # New height: 430
 
     # ============================== Parsing args ============================== #
 
@@ -340,7 +340,7 @@ if __name__ == "__main__":
         nargs = 4,
         help = "Crop image: [TOP, RIGHT, BOTTOM, LEFT]. Must always be 4 ints. Non-cropped sizes are 0.",
         metavar = ("TOP", "RIGHT", "BOTTOM", "LEFT"),
-        default = [0, 390, 160, 390],    # 2 plus 2 is 4 minus 1 that's 3, quick maths
+        default = [0, 100, 160, 100],    # 2 plus 2 is 4 minus 1 that's 3, quick maths
         required = False
     )
     parser.add_argument(

--- a/EgoPath/create_path/TuSimple/parse_tusimple_bev.py
+++ b/EgoPath/create_path/TuSimple/parse_tusimple_bev.py
@@ -484,7 +484,7 @@ if __name__ == "__main__":
     }
     BEV_W = 640
     BEV_H = 1280
-    EGO_HEIGHT_RATIO = 1
+    EGO_HEIGHT_RATIO = 1.05
     BEV_Y_STEP = 128
     POLYFIT_ORDER = 2
 

--- a/EgoPath/create_path/TuSimple/parse_tusimple_bev.py
+++ b/EgoPath/create_path/TuSimple/parse_tusimple_bev.py
@@ -484,7 +484,7 @@ if __name__ == "__main__":
     }
     BEV_W = 640
     BEV_H = 1280
-    EGO_HEIGHT_RATIO = 1.05
+    EGO_HEIGHT_RATIO = 1
     BEV_Y_STEP = 128
     POLYFIT_ORDER = 2
 


### PR DESCRIPTION
This PR finalizes CULane dataset parsing for AutoSteer training pipeline. The JSON has groundtruths for:
- Original perspective: egopath, egoleft, egoright
- BEV perspective: egopath, egoleft, egoright, each has:
    - x-coordinate (normalized)
    - y-coordinate (normalized)
    - `flag` and `valid` to specify if a point is within BEV perspective

### Usage

#### Outputs

```bash
--output_dir
    ├── image_bev/            # BEV-transformed images
    ├── visualization_bev/    # BEV + reprojected visualization
    ├── drivable_path_bev.json   # Polyfitted BEV + reprojected annotations
    └── skipped_frames.json      # Log of skipped frames with reasons
```

#### Args

- `--dataset_dir` (required)
  - Path to the processed CULane dataset directory (i.e., the output directory from `process_culane.py`).
  - Example : `../pov_datasets/CULANE`

- `--early_stopping` (optional)
  - Limits the number of frames processed. Useful for debugging or quick testing, default `None` (processes all frames).
  - Example : `--early_stopping 100`

#### Running the script

Once you have processed the CULane dataset using `process_culane.py`, you can run the BEV transformation script to generate BEV views and reprojected visualizations.

```bash
python3 EgoPath/create_path/CULane/parse_culane_bev.py \
  --dataset_dir ../pov_datasets/CULANE
```

You can limit the number of frames for debugging or development purposes. This will process first 100 frames.

```bash
python3 EgoPath/create_path/CULane/parse_culane_bev.py \
  --dataset_dir ../pov_datasets/CULANE \
  --early_stopping 100
```