### PR TITLE
PathFinder fixes & Longitudinal Controller ROS2 package

### DIFF
--- a/Control/Longitudinal/PI_Controller/CMakeLists.txt
+++ b/Control/Longitudinal/PI_Controller/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.10)
+project(PI_Controller)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+add_executable(PI_Controller
+    src/main.cpp
+    src/pi_controller.cpp
+)
+
+add_library(pi_controller_lib
+    src/pi_controller.cpp
+)
+target_include_directories(pi_controller_lib PUBLIC include)

--- a/Control/Longitudinal/PI_Controller/include/pi_controller.hpp
+++ b/Control/Longitudinal/PI_Controller/include/pi_controller.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <iostream>
+#include <cmath>
+
+class PI_Controller
+{
+public:
+    PI_Controller(double K_p, double K_i);
+    double computeEffort(double current_speed_, double target_speed_);
+
+private:
+    double K_p, K_i, integral_error;
+};

--- a/Control/Longitudinal/PI_Controller/src/main.cpp
+++ b/Control/Longitudinal/PI_Controller/src/main.cpp
@@ -1,0 +1,16 @@
+#include "pi_controller.hpp"
+
+int main()
+{
+    PI_Controller pi(0.1, 0.01);
+    double current_speed = 5.0; // current speed in m/s
+    double target_speed = 15.0; // target speed in m/s  
+
+    int i = 5;
+    while (i--){
+        std::cout << pi.computeEffort(current_speed, target_speed) << std::endl;
+        current_speed += 2.0; // Simulate speed increase
+    }
+  
+    return 0;
+}

--- a/Control/Longitudinal/PI_Controller/src/pi_controller.cpp
+++ b/Control/Longitudinal/PI_Controller/src/pi_controller.cpp
@@ -1,0 +1,19 @@
+#include "pi_controller.hpp"
+
+PI_Controller::PI_Controller(double K_p, double K_i)
+{
+    std::cout << "PI controller init with Params \n"
+              << "K_p\t" << K_p << "\n"
+              << "K_i\t" << K_i << "\n";
+    integral_error = 0.0;
+    this->K_p = K_p;
+    this->K_i = K_i;
+}
+
+double PI_Controller::computeEffort(double current_speed_, double target_speed_)
+{
+    double error = target_speed_ - current_speed_;
+    integral_error += error;
+    double effort = K_p * error + K_i * integral_error;
+    return effort;
+}

--- a/VisionPilot/ROS2/PATHFINDER/include/PATHFINDER/path_finder.hpp
+++ b/VisionPilot/ROS2/PATHFINDER/include/PATHFINDER/path_finder.hpp
@@ -8,6 +8,7 @@
 #include <yaml-cpp/yaml.h>
 #include <Eigen/Dense>
 #include <filesystem>
+#include <optional>
 #include "estimator.hpp"
 
 struct LanePts
@@ -30,26 +31,20 @@ struct fittedCurve
 };
 
 struct drivingCorridor{
-    std::optional<fittedCurve> egoLaneL;
-    std::optional<fittedCurve> egoLaneR;
-    std::optional<fittedCurve> egoPath;
+    fittedCurve egoLaneL;
+    fittedCurve egoLaneR;
+    fittedCurve egoPath;
     double cte;                  // Cross-track error in meters
     double yaw_error;            // Yaw error in radians
     double curvature;            // Curvature in meters^-1
     double width;
     drivingCorridor(
-        const std::optional<fittedCurve>& left,
-        const std::optional<fittedCurve>& right,
-        const std::optional<fittedCurve>& path);
+        const fittedCurve &left,
+        const fittedCurve &right,
+        const fittedCurve &path);
 };
 
-void drawLanes(const std::vector<LanePts> &lanes,
-               const std::vector<fittedCurve> &egoLanes,
-               const fittedCurve &egoPath);
-std::vector<LanePts> loadLanesFromYaml(const std::string &filename, cv::Mat &H);
-std::array<double, 2> generatePixelNoise(double max_noise);
 std::array<double, 3> fitQuadPoly(const std::vector<cv::Point2f> &points);
 cv::Mat loadHFromYaml(const std::string &filename);
-void cameraView(const std::vector<std::vector<cv::Point2f>> &lanes2d);
 fittedCurve calculateEgoPath(const fittedCurve &leftLane, const fittedCurve &rightLane);
 void estimateH(const std::string &filename);

--- a/VisionPilot/ROS2/PATHFINDER/include/PATHFINDER/pathfinder_node.hpp
+++ b/VisionPilot/ROS2/PATHFINDER/include/PATHFINDER/pathfinder_node.hpp
@@ -28,12 +28,12 @@ private:
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pub_laneR_;
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pub_path_;
     rclcpp::TimerBase::SharedPtr timer_;
-    std::array<double, 3UL> pathMsg2Coeff(const nav_msgs::msg::Path::SharedPtr &msg);
+    std::optional<std::array<double, 3UL>> pathMsg2Coeff(const nav_msgs::msg::Path::SharedPtr &msg);
     Estimator bayesFilter;
     const double proc_SD = 0.2;
     const double meas_SD = 0.2;
     const double epsilon = 0.01;
-    std::array<double, 3UL> left_coeff;
-    std::array<double, 3UL> right_coeff;
-    std::array<double, 3UL> path_coeff;
+    nav_msgs::msg::Path::SharedPtr left_msg;
+    nav_msgs::msg::Path::SharedPtr right_msg;
+    nav_msgs::msg::Path::SharedPtr path_msg;
 };

--- a/VisionPilot/ROS2/PATHFINDER/src/path_finder.cpp
+++ b/VisionPilot/ROS2/PATHFINDER/src/path_finder.cpp
@@ -1,8 +1,5 @@
 #include "path_finder.hpp"
 
-// TODO: fuse yaw_error and curv using product of Gaussians
-bool gt = true; // true for ground truth, false for BEV points
-
 LanePts::LanePts(int id,
                  std::vector<cv::Point2f> GtPoints,
                  std::vector<cv::Point2f> BevPoints) : id(id), GtPoints(GtPoints), BevPoints(BevPoints) {}
@@ -15,143 +12,27 @@ fittedCurve::fittedCurve(const std::array<double, 3> &coeff) : coeff(coeff)
 }
 
 drivingCorridor::drivingCorridor(
-    const std::optional<fittedCurve> &left,
-    const std::optional<fittedCurve> &right,
-    const std::optional<fittedCurve> &path)
-    : egoLaneL(left), egoLaneR(right), egoPath(path)
+                 const fittedCurve &left,
+                 const fittedCurve &right,
+                 const fittedCurve &path)
+    : egoLaneL(left), egoLaneR(right), egoPath(path), width(4.0)
 {
-    if (egoLaneL && egoLaneR)
-    {
-        if (!egoPath)
-        {
-            egoPath = fittedCurve({(egoLaneL->coeff[0] + egoLaneR->coeff[0]) / 2.0,
-                                   (egoLaneL->coeff[1] + egoLaneR->coeff[1]) / 2.0,
-                                   (egoLaneL->coeff[2] + egoLaneR->coeff[2]) / 2.0});
-        }
-        width = egoLaneL->cte - egoLaneR->cte;
+    //TODO: deal with missing lanes here
+    // if (egoLaneL && egoLaneR)
+    // {
+    //     if (!egoPath)
+    //     {
+            const auto &cl = egoLaneL.coeff;
+            const auto &cr = egoLaneR.coeff;
+            egoPath = fittedCurve({
+                            (cl[0] + cr[0]) / 2.0,
+                            (cl[1] + cr[1]) / 2.0,
+                            (cl[2] + cr[2]) / 2.0
+                        });
+        // }
+        width = egoLaneL.cte - egoLaneR.cte;
         std::cout << "corridor width is " << width << std::endl;
-    }
-}
-
-void drawLanes(const std::vector<LanePts> &lanes,
-               const std::vector<fittedCurve> &egoLanes,
-               const fittedCurve &egoPath)
-{
-    int width = 800, height = 1000, scale = 20, height_offset = 50;
-    cv::Mat image = cv::Mat::zeros(height, width, CV_8UC3);
-    cv::line(image, cv::Point(width / 2, 0), cv::Point(width / 2, height), cv::Scalar(255, 255, 255), 1); // white centerline
-    cv::circle(image, cv::Point(width / 2, height - height_offset), 5, cv::Scalar(0, 0, 255), -1);        // red dot
-
-    int color = 0;
-    for (const auto &lane : lanes)
-    {
-        int prev_u, prev_v;
-        color += 20;
-        std::vector<cv::Point2f> points;
-        if (gt)
-            points = lane.GtPoints;
-        else
-            points = lane.BevPoints;
-
-        for (int i = 0; i < points.size(); i++)
-        {
-            const auto pt_m = points[i];
-            int u = pt_m.x * scale + width / 2;
-            int v = height - height_offset - pt_m.y * scale;
-            cv::Point pt_pix(u, v);
-            cv::circle(image, pt_pix, 3, cv::Scalar(255 - color, color, 0), -1); // green dots
-            if (i > 0)
-            {
-                cv::Point prev(prev_u, prev_v);
-                cv::line(image, prev, pt_pix, cv::Scalar(0, 255, 0), 1); // green line
-            }
-            prev_u = u;
-            prev_v = v;
-        }
-    }
-
-    color = 0;
-    for (auto egoLane : egoLanes)
-    {
-        cv::Point2f prev_pt(0, 0);
-        for (double y = 0.0; y <= 50.0; y += 0.1) // y range in meters
-        {
-            double x = egoLane.coeff[0] * y * y + egoLane.coeff[1] * y + egoLane.coeff[2];
-            int u = static_cast<int>(x * scale + width / 2);
-            int v = static_cast<int>(height - height_offset - y * scale);
-            if (y > 0.0) // skip the first point
-            {
-                cv::line(image, prev_pt, cv::Point2f(u, v), cv::Scalar(0, color, 255), 1); // yellow
-            }
-            prev_pt.x = u;
-            prev_pt.y = v;
-        }
-        color += 100;
-    }
-
-    // Draw ego path
-    cv::Point2f prev_pt(0, 0);
-    for (double y = 0.0; y <= 50.0; y += 0.1) // y range in meters
-    {
-        double x = egoPath.coeff[0] * y * y + egoPath.coeff[1] * y + egoPath.coeff[2];
-        int u = static_cast<int>(x * scale + width / 2);
-        int v = static_cast<int>(height - height_offset - y * scale);
-        if (y > 0.0) // skip the first point
-        {
-            cv::line(image, prev_pt, cv::Point2f(u, v), cv::Scalar(255, 0, 0), 2);
-        }
-        prev_pt.x = u;
-        prev_pt.y = v;
-    }
-
-    cv::imshow("BEV Lanes", image);
-    // cv::imwrite("../test/bev_lanes.png", image);
-    cv::waitKey(0);
-    cv::destroyAllWindows();
-}
-
-std::vector<LanePts> loadLanesFromYaml(const std::string &filename, cv::Mat &H)
-{
-    std::vector<LanePts> lanes;
-    YAML::Node root = YAML::LoadFile(filename);
-    int i = 0;
-    for (const auto &lane3d : root["lanes3d"])
-    {
-        const auto &lane2d = root["lanes2d"][i++];
-        // std::cout << "LanePts " << i << ":\n";
-        std::vector<cv::Point2f> lane_pixels;
-        for (const auto &pt2d : lane2d)
-        {
-            // std::cout << "  [" << pt2d[0].as<double>() << ", " << pt2d[1].as<double>() << "]\n";
-            auto noise = generatePixelNoise(5.0);
-            double u = pt2d[0].as<double>(); //+ noise[0];
-            double v = pt2d[1].as<double>(); //+ noise[1];
-            lane_pixels.emplace_back(cv::Point2f(u, v));
-        }
-        std::vector<cv::Point2f> bev_pixels;
-        cv::perspectiveTransform(lane_pixels, bev_pixels, H);
-
-        std::vector<cv::Point2f> gt_pts;
-        for (const auto &pt3d : lane3d)
-        {
-            // std::cout << "  [" << pt3d[0].as<double>() << ", "
-            //           << pt3d[1].as<double>() << ", "
-            //           << pt3d[2].as<double>() << "]\n";
-            gt_pts.emplace_back(cv::Point2f(pt3d[0].as<double>(), pt3d[2].as<double>()));
-        }
-        lanes.emplace_back(i, gt_pts, bev_pixels);
-    }
-    return lanes;
-}
-
-std::array<double, 2> generatePixelNoise(double max_noise = 10.0)
-{
-    static std::random_device rd;
-    static std::mt19937 gen(rd());
-    std::uniform_real_distribution<> dist_pix(-max_noise, max_noise);
-    double du = dist_pix(gen);
-    double dv = dist_pix(gen);
-    return {du, dv}; // Pixel-space noise to be added to (u, v)
+//     }
 }
 
 cv::Mat loadHFromYaml(const std::string &filename)
@@ -174,30 +55,6 @@ cv::Mat loadHFromYaml(const std::string &filename)
     // std::cout << "Loaded H:\n"
     //           << H << std::endl;
     return H;
-}
-
-void cameraView(const std::vector<std::vector<cv::Point2f>> &lanes2d) // camera perspective
-{
-    // Create blank image
-    int width = 1920, height = 1020;
-    cv::Mat image = cv::Mat::zeros(height, width, CV_8UC3);
-
-    // Draw each lane
-    for (const auto &lane : lanes2d)
-    {
-        for (size_t i = 0; i < lane.size(); ++i)
-        {
-            cv::circle(image, lane[i], 3, cv::Scalar(0, 255, 0), -1); // green dots
-
-            // Optionally connect points with a line
-            if (i > 0)
-            {
-                cv::line(image, lane[i - 1], lane[i], cv::Scalar(255, 0, 0), 1); // blue line
-            }
-        }
-    }
-    cv::imshow("Camera View", image);
-    cv::waitKey(0);
 }
 
 std::array<double, 3> fitQuadPoly(const std::vector<cv::Point2f> &points)
@@ -271,215 +128,3 @@ fittedCurve calculateEgoPath(const fittedCurve &leftLane, const fittedCurve &rig
                         (leftLane.coeff[1] + rightLane.coeff[1]) / 2.0,
                         (leftLane.coeff[2] + rightLane.coeff[2]) / 2.0});
 }
-
-const std::vector<std::pair<int, int>> lanePairs = { // manually label LR egoLanes
-    {2, 1},
-    {2, 0},
-    {2, 0},
-    {1, 0},
-    {0, 2},
-    {2, 0},
-    {2, 1},
-    {3, 0}};
-
-// int main()
-// {
-//     namespace fs = std::filesystem;
-//     std::vector<std::pair<std::string, std::string>> file_pairs;
-//     for (const auto &entry : fs::directory_iterator("../test/000001"))
-//     {
-//         if (entry.is_regular_file() && entry.path().extension() == ".yaml")
-//         {
-//             std::string stem = entry.path().stem().string();
-//             std::string yaml_path = entry.path().string();
-//             std::string img_path = "../test/000001/img/" + stem + ".jpg";
-
-//             std::cout << "Found YAML file: " << stem << std::endl;
-//             file_pairs.emplace_back(yaml_path, img_path);
-//         }
-//     }
-
-//     // Sort numerically by ID (stem of filename)
-//     std::sort(file_pairs.begin(), file_pairs.end(),
-//               [](const auto &a, const auto &b)
-//               {
-//                   return std::stoll(fs::path(a.first).stem().string()) <
-//                          std::stoll(fs::path(b.first).stem().string());
-//               });
-
-//     std::vector<fittedCurve> egoPaths, egoPathsGT;
-//     std::vector<drivingCorridor> drivCorr, drivCorrGT;
-
-//     int i = 0;
-//     std::cout << "Found " << file_pairs.size() << " YAML files." << std::endl;
-//     for (const auto &file_pair : file_pairs)
-//     {
-//         auto egoLanesPts = loadLanesFromYaml(file_pair.first);
-//         if (egoLanesPts.size() < 2)
-//         {
-//             std::cerr << "Not enough lanes to calculate ego path. Loop id: " << i << std::endl;
-//             continue;
-//         }
-//         auto egoLanesPtsLR = {egoLanesPts[lanePairs[i].first], egoLanesPts[lanePairs[i].second]};
-//         i++;
-
-//         std::vector<fittedCurve> egoLanes, egoLanesGT;
-
-//         for (auto lanePts : egoLanesPtsLR)
-//         {
-//             std::array<double, 3> coeff_gt = fitQuadPoly(lanePts.GtPoints);
-//             std::array<double, 3> coeff = fitQuadPoly(lanePts.BevPoints);
-//             egoLanesGT.emplace_back(fittedCurve(coeff_gt));
-//             egoLanes.emplace_back(fittedCurve(coeff));
-//         }
-
-//         drivCorr.emplace_back(egoLanes[0], egoLanes[1], std::nullopt);
-//         drivCorrGT.emplace_back(egoLanesGT[0], egoLanesGT[1], std::nullopt);
-
-//         cv::Mat img = cv::imread(file_pair.second, cv::IMREAD_COLOR);
-//         if (img.empty())
-//         {
-//             std::cerr << "Failed to load image: " << file_pair.second << std::endl;
-//             continue;
-//         }
-//         cv::imshow("Camera View", img);
-
-//         drawLanes(egoLanesPts, egoLanes, drivCorr.back().egoPath.value());
-//     }
-
-//     // ----------------------
-//     auto bayesFilter = Estimator(); // Keeps track of individual sources
-//     bayesFilter.configureFusionGroups({
-//         // {start_idx,end_idx}
-//         // fuse indices 1,2 → result in index 3
-//         {0, 3}, // cte1, cte2 → fused at index 3
-//         {5, 7}, // yaw1, yaw2 → fused at index 7
-//         {9, 11} // curv1, curv2 → fused at index 11
-//     });
-
-//     const double proc_SD = 0.5;
-//     const double meas_SD = 0.5;
-//     const double epsilon = 0.05;
-//     std::random_device rd;
-//     std::default_random_engine generator(rd());
-//     std::uniform_real_distribution<double> dist(-epsilon, epsilon);
-//     std::cout << "process standard dev: " << proc_SD << std::endl;
-//     std::cout << "process mean random shift range: +-" << epsilon << std::endl;
-//     std::cout << "measurement standard dev: " << meas_SD << std::endl;
-
-//     // cte, yaw_error, curvature, driving corridor width
-//     std::array<Gaussian, STATE_DIM> measurement;
-//     std::array<Gaussian, STATE_DIM> process;
-
-//     for (size_t i = 0; i < STATE_DIM; ++i)
-//     {
-//         process[i].mean = dist(generator);
-//         process[i].variance = proc_SD * proc_SD;
-//         measurement[i].variance = meas_SD * meas_SD;
-//     }
-
-//     // Main loop
-//     for (int i = 0; i < drivCorr.size(); ++i)
-//     {
-//         const auto &egoPath = drivCorr[i].egoPath;
-//         const auto &egoLaneL = drivCorr[i].egoLaneL;
-//         const auto &egoLaneR = drivCorr[i].egoLaneR;
-//         const auto &egoPathGT = drivCorrGT[i].egoPath;
-
-//         measurement[0].mean = egoPath->cte;
-//         measurement[1].mean = egoLaneL->cte - drivCorr[i].width / 2.0;
-//         measurement[2].mean = egoLaneR->cte + drivCorr[i].width / 2.0;
-//         measurement[3].mean = 0.0;
-
-//         measurement[4].mean = egoPath->yaw_error;
-//         measurement[5].mean = egoLaneL->yaw_error;
-//         measurement[6].mean = egoLaneR->yaw_error;
-//         measurement[7].mean = 0.0;
-
-//         measurement[8].mean = egoPath->curvature;
-//         measurement[9].mean = egoLaneL->curvature;
-//         measurement[10].mean = egoLaneR->curvature;
-//         measurement[11].mean = 0.0;
-
-//         measurement[12].mean = drivCorr[i].width;
-
-//         if (i == 0)
-//         {
-//             bayesFilter.initialize(measurement);
-//         }
-//         else
-//         {
-//             bayesFilter.update(measurement);
-//         }
-
-//         const auto &state = bayesFilter.getState();
-
-//         std::cout << std::fixed << std::setprecision(4);
-//         int w = 8;
-//         // Header
-//         std::cout << "Frame " << i << "\n";
-//         std::cout << "\033[32m"
-//                   << std::setw(w) << "Label"
-//                   << std::setw(w) << "M_CTE" << std::setw(w) << "var"
-//                   << std::setw(w) << "L_CTE" << std::setw(w) << "var"
-//                   << std::setw(w) << "R_CTE" << std::setw(w) << "var"
-//                   << std::setw(w) << "MLR_CTE" << std::setw(w) << "var"
-//                   << std::setw(w) << "M_Yaw" << std::setw(w) << "var"
-//                   << std::setw(w) << "L_Yaw" << std::setw(w) << "var"
-//                   << std::setw(w) << "R_Yaw" << std::setw(w) << "var"
-//                   << std::setw(w) << "LR_Yaw" << std::setw(w) << "var"
-//                   << std::setw(w) << "M_Curv" << std::setw(w) << "var"
-//                   << std::setw(w) << "L_Curv" << std::setw(w) << "var"
-//                   << std::setw(w) << "R_Curv" << std::setw(w) << "var"
-//                   << std::setw(w) << "LR_Curv" << std::setw(w) << "var"
-//                   << std::setw(w) << "Width" << std::setw(w) << "var"
-//                   << std::endl;
-//         std::cout << "\033[0m\n";
-
-//         // Ground Truth
-//         std::vector<double> gt_values = {
-//             egoPathGT->cte,
-//             drivCorrGT[i].egoLaneL->cte - drivCorrGT[i].width / 2.0,
-//             drivCorrGT[i].egoLaneR->cte + drivCorrGT[i].width / 2.0,
-//             egoPathGT->cte,
-//             egoPathGT->yaw_error,
-//             drivCorrGT[i].egoLaneL->yaw_error,
-//             drivCorrGT[i].egoLaneR->yaw_error,
-//             egoPathGT->yaw_error,
-//             egoPathGT->curvature,
-//             drivCorrGT[i].egoLaneL->curvature,
-//             drivCorrGT[i].egoLaneR->curvature,
-//             egoPathGT->curvature,
-//             drivCorrGT[i].width};
-
-//         std::cout << std::setw(w) << "GT:";
-//         for (double v : gt_values)
-//             std::cout << std::setw(w) << v << std::setw(w) << "";
-//         std::cout << "\n";
-
-//         // Measurement
-//         std::cout << std::setw(w) << "Meas:";
-//         for (size_t j = 0; j < STATE_DIM; ++j)
-//             std::cout << std::setw(w) << measurement[j].mean
-//                       << std::setw(w) << measurement[j].variance;
-//         std::cout << "\n";
-
-//         // Filter Estimate
-//         std::cout << std::setw(w) << "Filter:";
-//         for (size_t j = 0; j < STATE_DIM; ++j)
-//             std::cout << std::setw(w) << state[j].mean
-//                       << std::setw(w) << state[j].variance;
-//         std::cout << "\n";
-
-//         // Error
-//         std::cout << "\033[31m" << std::setw(w) << "Error:";
-//         for (size_t j = 0; j < STATE_DIM; ++j)
-//             std::cout << std::setw(w) << (gt_values[j] - state[j].mean)
-//                       << std::setw(w) << "";
-//         std::cout << "\033[0m\n";
-
-//         std::cout << "-----------------------------------------------------------------------------------------------------------\n";
-
-//         bayesFilter.predict(process);
-//     }
-// }

--- a/VisionPilot/ROS2/longitudinal_controller/CMakeLists.txt
+++ b/VisionPilot/ROS2/longitudinal_controller/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.8)
+project(longitudinal_controller)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_subdirectory(
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../Control/Longitudinal/PI_Controller
+    ${CMAKE_CURRENT_BINARY_DIR}/pi_controller_build
+)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(carla_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+add_executable(longitudinal_controller_node 
+    src/longitudinal_controller_node.cpp
+    )
+
+target_link_libraries(longitudinal_controller_node pi_controller_lib)
+
+target_include_directories(longitudinal_controller_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_compile_features(longitudinal_controller_node PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+
+ament_target_dependencies(longitudinal_controller_node rclcpp std_msgs carla_msgs nav_msgs)
+
+install(TARGETS longitudinal_controller_node
+  DESTINATION lib/${PROJECT_NAME})
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}/
+)
+
+ament_package()

--- a/VisionPilot/ROS2/longitudinal_controller/README.md
+++ b/VisionPilot/ROS2/longitudinal_controller/README.md
@@ -1,0 +1,14 @@
+## Steering Controller
+
+ROS2 C++ node responsible for computing the required throttle and brake to reach and maintain the desired longitudinal speed.
+
+## Dependencies
+
+## How it works
+
+## Subscription
+- /odom (`nav_msgs/Odometry`)
+
+## Publisher
+Throttle
+Brake

--- a/VisionPilot/ROS2/longitudinal_controller/include/longitudinal_controller_node.hpp
+++ b/VisionPilot/ROS2/longitudinal_controller/include/longitudinal_controller_node.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include "pi_controller.hpp"
+#include <carla_msgs/msg/carla_ego_vehicle_control.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+class LongitudinalControllerNode : public rclcpp::Node
+{
+public:
+    LongitudinalControllerNode(const rclcpp::NodeOptions &options);
+    rclcpp::Publisher<carla_msgs::msg::CarlaEgoVehicleControl>::SharedPtr control_pub_;
+    rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+    void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
+
+private:
+    PI_Controller pi_controller_;
+    double integral_error_, forward_velocity_;
+};

--- a/VisionPilot/ROS2/longitudinal_controller/launch/longitudinal_controller_launch.py
+++ b/VisionPilot/ROS2/longitudinal_controller/launch/longitudinal_controller_launch.py
@@ -1,0 +1,20 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='longitudinal_controller',  
+            executable='longitudinal_controller_node',
+            name='longitudinal_controller_node',
+            output='screen'
+        ),
+        
+        Node(
+            package='odom_publisher',
+            executable='pub_odom_node',
+            name='pub_odom_node',
+            output='screen'
+        )
+
+    ])

--- a/VisionPilot/ROS2/longitudinal_controller/package.xml
+++ b/VisionPilot/ROS2/longitudinal_controller/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>longitudinal_controller</name>
+  <version>0.0.0</version>
+  <description> ROS2 node to control throttle and brake</description>
+  <maintainer email="limjitern@gmail.com">JITERN</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>carla_msgs</depend>
+  <depend>nav_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/VisionPilot/ROS2/longitudinal_controller/src/longitudinal_controller_node.cpp
+++ b/VisionPilot/ROS2/longitudinal_controller/src/longitudinal_controller_node.cpp
@@ -1,0 +1,50 @@
+#include "longitudinal_controller_node.hpp"
+
+LongitudinalControllerNode::LongitudinalControllerNode(const rclcpp::NodeOptions &options)
+    : Node("steering_controller_node", "", options),
+      pi_controller_(1.0, 0.01)
+{
+  this->set_parameter(rclcpp::Parameter("use_sim_time", true));
+  odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>("/hero/odom", 10, std::bind(&LongitudinalControllerNode::odomCallback, this, std::placeholders::_1));
+  control_pub_ = this->create_publisher<carla_msgs::msg::CarlaEgoVehicleControl>("carla/hero/vehicle_control_cmd", 10);
+  RCLCPP_INFO(this->get_logger(), "LongitudinalController Node started");
+  integral_error_ = 0.0;
+  forward_velocity_ = 0.0;
+}
+
+void LongitudinalControllerNode::odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+{
+  forward_velocity_ = msg->twist.twist.linear.x; // [m/s]
+  double v_ref = 22.22; // [m/s]
+  double error = v_ref - forward_velocity_;
+
+  // Integrator update (with anti-windup)
+  integral_error_ += error * 0.01;
+  integral_error_ = std::clamp(integral_error_, -5.0, 5.0); // limit integral windup
+
+  double kp = 1.0;
+  double ki = 0.07;
+  double u = kp * error + ki * integral_error_;
+
+  double throttle_cmd = (u > 0.0) ? std::clamp(u, 0.0, 1.0) : 0.0;
+  double brake_cmd = (u < 0.0) ? std::clamp(-u, 0.0, 1.0) : 0.0;
+
+  //TODO construct this message in a separate node
+  auto control_msg = carla_msgs::msg::CarlaEgoVehicleControl();
+  control_msg.header.stamp = this->now();
+  control_msg.steer = 0.0;
+  control_msg.throttle = throttle_cmd;
+  control_msg.brake = brake_cmd;
+  control_msg.hand_brake = false;
+  control_msg.reverse = false;
+  control_msg.manual_gear_shift = false;
+  control_pub_->publish(control_msg);
+}
+
+int main(int argc, char *argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<LongitudinalControllerNode>(rclcpp::NodeOptions()));
+  rclcpp::shutdown();
+  return 0;
+}

--- a/VisionPilot/ROS2/steering_controller/README.md
+++ b/VisionPilot/ROS2/steering_controller/README.md
@@ -1,7 +1,6 @@
-## Pure Pursuit
+## Steering Controller
 
-ROS2 C++ node responsible for computing the required steering angle to follow the desired path. 
-
+ROS2 C++ node responsible for computing the required steering angle to follow the desired path.
 
 ## Dependencies
 

--- a/VisionPilot/ROS2/steering_controller/src/steering_controller_node.cpp
+++ b/VisionPilot/ROS2/steering_controller/src/steering_controller_node.cpp
@@ -1,12 +1,10 @@
 #include "steering_controller_node.hpp"
 
-  // it is observed that turning radius increases with speed, with the same steering angle command
-  // velocity m/s, turning radius m
-  // <=2.5 , 3.0
-  // 5.0   , 3.5
-  // 7.5   , 4
-
-// TODO: separate longitudinal PI controller core cpp implementation from ROS2 node
+// it is observed that turning radius increases with speed, with the same steering angle command
+// velocity m/s, turning radius m
+// <=2.5 , 3.0
+// 5.0   , 3.5
+// 7.5   , 4
 
 SteeringControllerNode::SteeringControllerNode(const rclcpp::NodeOptions &options) : Node("steering_controller_node", "", options),
                                                                                     sc(2.85, 2.0, 2.8, 1.0, 4.0)
@@ -26,40 +24,7 @@ SteeringControllerNode::SteeringControllerNode(const rclcpp::NodeOptions &option
 
 void SteeringControllerNode::odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
-  double vx = msg->twist.twist.linear.x;
-  double vy = msg->twist.twist.linear.y;
-  forward_velocity_ = vx; // convert to km/h
-
-  // ------------------------------
-  // PI Controller for throttle
-  // ------------------------------
-  double v_ref = 22.22; // [m/s]
-  double error = v_ref - vx;
-
-  // Integrator update (with anti-windup)
-  integral_error_ += error * 0.01;
-  integral_error_ = std::clamp(integral_error_, -5.0, 5.0); // limit integral windup
-
-  double kp = 1.0;
-  double ki = 0.07;
-  double u = kp * error + ki * integral_error_;
-
-  double throttle_cmd = (u > 0.0) ? std::clamp(u, 0.0, 1.0) : 0.0;
-  double brake_cmd = (u < 0.0) ? std::clamp(-u, 0.0, 1.0) : 0.0;
-
-  auto control_msg = carla_msgs::msg::CarlaEgoVehicleControl();
-  control_msg.header.stamp = this->now();
-  // TODO: ackermann model with 48deg and 70deg, turning radius seems to be f(steering_angle, speed)
-  // control_msg.steer = std::clamp((180.0 / M_PI) * (steering_angle_ / 49.0), -1.0, 1.0); // 49deg is for low speeds 0.5m/s
-
-  control_msg.steer = std::clamp((180.0 / M_PI) * (steering_angle_ / 49.0), -1.0, 1.0);
-
-  control_msg.throttle = throttle_cmd;
-  control_msg.brake = brake_cmd;
-  control_msg.hand_brake = false;
-  control_msg.reverse = false;
-  control_msg.manual_gear_shift = false;
-  steering_pub_->publish(control_msg);
+  forward_velocity_ = msg->twist.twist.linear.x; // in m/s
 }
 
 void SteeringControllerNode::stateCallback(const std_msgs::msg::Float32MultiArray::SharedPtr msg)
@@ -73,6 +38,18 @@ void SteeringControllerNode::stateCallback(const std_msgs::msg::Float32MultiArra
   yaw_error_ = msg->data[7];
   curvature_ = msg->data[11];
   steering_angle_ = sc.computeSteering(cte_, yaw_error_, forward_velocity_, curvature_);
+
+  auto control_msg = carla_msgs::msg::CarlaEgoVehicleControl();
+  control_msg.header.stamp = this->now();
+  // TODO: ackermann model with 48deg and 70deg, turning radius seems to be f(steering_angle, speed)
+  // control_msg.steer = std::clamp((180.0 / M_PI) * (steering_angle_ / 49.0), -1.0, 1.0); // 49deg is for low speeds 0.5m/s
+  control_msg.steer = std::clamp((180.0 / M_PI) * (steering_angle_ / 49.0), -1.0, 1.0);
+  control_msg.throttle = 0.6;
+  control_msg.brake = 0.0;
+  control_msg.hand_brake = false;
+  control_msg.reverse = false;
+  control_msg.manual_gear_shift = false;
+  steering_pub_->publish(control_msg);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
PathFinder Fixes:
- [ ] Default 4m lane width and cross-track error of left and right egoLanes should be +-2m with missing lane detections
- [ ] Test by artificially removing simulated lane detections published from road_shape_publisher node

Longitudinal PI Controller:
- [ ] Extract core cpp lib
- [ ] ROS2 Standalone longitudinal control node

Simulation Pipeline:
- [ ] Simulate missing lane detection in road_shape_publisher node
- [ ] ROS2 node to merge steering and longitudinal control ouputs into carla control msg