### PR TITLE
Can bus interface

### DIFF
--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -16,3 +16,20 @@ struct CanVehicleState {
     double steering_angle_deg = std::numeric_limits<double>::quiet_NaN();   // Steering, CAN ID 0xA4
     bool is_valid = false;
 };
+
+/**
+ * @brief CAN Interface for hardware (SocketCAN) and file replay (.asc)
+ * - If interface_name ends with ".asc" : file replay.
+ * - Otherwise : open a SocketCAN interface (real-time inference).
+ */
+class CanInterface {
+public:
+    /**
+     * @brief Constructor
+     * @param interface_name "can0", "vcan0", or path to .asc file (e.g. "./assets/test.asc")
+     */
+    explicit CanInterface(const std::string& interface_name);
+    
+    ~CanInterface();
+
+    

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -83,3 +83,7 @@ private:
     double decodeSteering(const std::vector<uint8_t>& data);
     
 };
+
+} // namespace autoware_pov::drivers
+
+#endif // AUTOWARE_POV_DRIVERS_CAN_INTERFACE_HPP_

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -63,3 +63,8 @@ private:
     int socket_fd_ = -1;
     void setupSocket(const std::string& iface_name);
     bool readSocket();
+
+    // File replay (.asc)
+    std::ifstream file_stream_;
+    void setupFile(const std::string& file_path);
+    bool readFileLine();

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -47,6 +47,11 @@ public:
     CanVehicleState getState() const;
 
     /**
-     * @brief Check if we are in file replay mode
+     * @brief Check if in file replay
      */
     bool isReplayMode() const { return is_file_mode_; }
+
+private:
+    // State
+    CanVehicleState current_state_;
+    bool is_file_mode_ = false;

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -45,3 +45,8 @@ public:
      * @brief Get latest decoded vehicle state
      */
     CanVehicleState getState() const;
+
+    /**
+     * @brief Check if we are in file replay mode
+     */
+    bool isReplayMode() const { return is_file_mode_; }

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -72,3 +72,10 @@ private:
     // Decoding IDs
     static constexpr int ID_SPEED = 0xA1;    // Or A1, 161
     static constexpr int ID_STEERING = 0xA4; // Or A4, 164
+
+    void parseFrame(
+        int can_id, 
+        const std::vector<uint8_t>& data
+    );
+    
+};

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -23,7 +23,9 @@ struct CanVehicleState {
  * - Otherwise : open a SocketCAN interface (real-time inference).
  */
 class CanInterface {
+
 public:
+
     /**
      * @brief Constructor
      * @param interface_name "can0", "vcan0", or path to .asc file (e.g. "./assets/test.asc")
@@ -52,6 +54,12 @@ public:
     bool isReplayMode() const { return is_file_mode_; }
 
 private:
+
     // State
     CanVehicleState current_state_;
     bool is_file_mode_ = false;
+
+    // Real-time inference (SocketCAN)
+    int socket_fd_ = -1;
+    void setupSocket(const std::string& iface_name);
+    bool readSocket();

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -40,3 +40,8 @@ public:
      * * @return true if new data was processed, false otherwise
      */
     bool update();
+
+    /**
+     * @brief Get latest decoded vehicle state
+     */
+    CanVehicleState getState() const;

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -68,3 +68,7 @@ private:
     std::ifstream file_stream_;
     void setupFile(const std::string& file_path);
     bool readFileLine();
+
+    // Decoding IDs
+    static constexpr int ID_SPEED = 0xA1;    // Or A1, 161
+    static constexpr int ID_STEERING = 0xA4; // Or A4, 164

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -32,4 +32,11 @@ public:
     
     ~CanInterface();
 
-    
+    /**
+     * @brief Read available CAN frames and update state
+     * * Call this once per cycle in main loop.
+     * In real-time inference : reads all frames currently in the socket buffer.
+     * In fie replay : reads the next line from the ASC file.
+     * * @return true if new data was processed, false otherwise
+     */
+    bool update();

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -80,6 +80,6 @@ private:
 
     double decodeSpeed(const std::vector<uint8_t>& data);
 
-    
+    double decodeSteering(const std::vector<uint8_t>& data);
     
 };

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -8,3 +8,11 @@
 #include <cmath>
 #include <limits>
 #include <chrono>
+
+namespace autoware_pov::drivers {
+
+struct CanVehicleState {
+    double speed_kmph = std::numeric_limits<double>::quiet_NaN();           // Speed, CAN ID 0xA1
+    double steering_angle_deg = std::numeric_limits<double>::quiet_NaN();   // Steering, CAN ID 0xA4
+    bool is_valid = false;
+};

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -1,0 +1,10 @@
+#ifndef AUTOWARE_POV_DRIVERS_CAN_INTERFACE_HPP_
+#define AUTOWARE_POV_DRIVERS_CAN_INTERFACE_HPP_
+
+#include <string>
+#include <optional>
+#include <fstream>
+#include <vector>
+#include <cmath>
+#include <limits>
+#include <chrono>

--- a/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
+++ b/VisionPilot/Production_Releases/0.5/include/drivers/can_interface.hpp
@@ -77,5 +77,9 @@ private:
         int can_id, 
         const std::vector<uint8_t>& data
     );
+
+    double decodeSpeed(const std::vector<uint8_t>& data);
+
+    
     
 };

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -136,6 +136,8 @@ double CanInterface::decodeSteering(const std::vector<uint8_t>& data) {
     return static_cast<double>(signed_val) * 0.1;
 }
 
+// ============================== REAL-TIME INFERENCE (SocketCAN) ============================== //
+
 // SocketCAN setup during real-time inference
 void CanInterface::setupSocket(
     const std::string& iface_name
@@ -214,4 +216,17 @@ bool CanInterface::readSocket() {
         data_received = true;
     }
     return data_received;
+}
+
+// ============================== FILE REPLAY (.asc) ============================== //
+
+void CanInterface::setupFile(
+    const std::string& file_path
+) {
+    
+    is_file_mode_ = true;
+    file_stream_.open(file_path);
+    if (!file_stream_.is_open()) {
+        std::cerr << "[CanInterface] Failed to open file: " << file_path << std::endl;
+    }
 }

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -17,6 +17,7 @@
 
 namespace autoware_pov::drivers {
 
+// Constructor
 CanInterface::CanInterface(
     const std::string& interface_name
 ) {
@@ -32,5 +33,15 @@ CanInterface::CanInterface(
         std::cout << "[CanInterface] Initializing real-time inference mode (SocketCAN): " 
                   << interface_name << std::endl;
         setupSocket(interface_name);
+    }
+}
+
+// Destructor
+CanInterface::~CanInterface() {
+    if (!is_file_mode_ && socket_fd_ >= 0) {
+        close(socket_fd_);
+    }
+    if (is_file_mode_ && file_stream_.is_open()) {
+        file_stream_.close();
     }
 }

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -313,3 +313,5 @@ bool CanInterface::readFileLine() {
     
     return false; // End of file
 }
+
+} // namespace autoware_pov::drivers

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -70,3 +70,24 @@ CanVehicleState CanInterface::getState() const {
     return current_state_;
 }
 
+// Decoding from CAN frame
+void CanInterface::parseFrame(
+    int can_id, 
+    const std::vector<uint8_t>& data
+) {
+
+    if (data.empty()) return;
+
+    // ID 0xA1 (A1, 161) => Speed
+    if (can_id == ID_SPEED) {
+        double val = decodeSpeed(data);
+        current_state_.speed_kmph = val;
+        current_state_.is_valid = true;
+    } 
+    // ID 0xA4 (A4, 164) => Steering angle
+    else if (can_id == ID_STEERING) {
+        double val = decodeSteering(data);
+        current_state_.steering_angle_deg = val;
+        current_state_.is_valid = true;
+    }
+}

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -108,3 +108,30 @@ double CanInterface::decodeSpeed(const std::vector<uint8_t>& data) {
     
     return static_cast<double>(raw) * 0.01;
 }
+
+// SSA (Steering angle) : Start Bit 46 | Length 15 | Signed | Factor 0.1
+// Format: Motorola (Big Endian: https://en.wikipedia.org/wiki/Endianness)
+// Bit 46 is in byte 5 (bit 6).
+// This is complex. We verify strictly against provided logic if possible.
+// Lacking exact bit-matrix, we assume standard Big Endian alignment crossing byte 5 and 6.
+double CanInterface::decodeSteering(const std::vector<uint8_t>& data) {
+    
+    if (data.size() < 8) return 0.0;
+
+    // Masking logic based on 15-bit signed integer
+    // Assuming MSB is in byte 5, LSB in byte 6
+    uint16_t raw_high = data[5];
+    uint16_t raw_low  = data[6];
+    
+    // Combine
+    uint16_t raw = (raw_high << 8) | raw_low;
+    
+    // If it's 15 bits, we might need to shift or mask. 
+    // Assuming the 15 bits are right-aligned in the extraction:
+    // (This is a best-guess implementation until A4 is actually observed in logs)
+    
+    // Convert to signed 16-bit to handle negative values (Two's complement)
+    int16_t signed_val = static_cast<int16_t>(raw);
+    
+    return static_cast<double>(signed_val) * 0.1;
+}

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -38,10 +38,28 @@ CanInterface::CanInterface(
 
 // Destructor
 CanInterface::~CanInterface() {
-    if (!is_file_mode_ && socket_fd_ >= 0) {
+
+    if (
+        !is_file_mode_ && 
+        socket_fd_ >= 0
+    ) {
         close(socket_fd_);
     }
-    if (is_file_mode_ && file_stream_.is_open()) {
+
+    if (
+        is_file_mode_ && 
+        file_stream_.is_open()
+    ) {
         file_stream_.close();
+    }
+}
+
+// Main update loop
+bool CanInterface::update() {
+    
+    if (is_file_mode_) {
+        return readFileLine();
+    } else {
+        return readSocket();
     }
 }

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -56,10 +56,17 @@ CanInterface::~CanInterface() {
 
 // Main update loop
 bool CanInterface::update() {
-    
+
     if (is_file_mode_) {
         return readFileLine();
     } else {
         return readSocket();
     }
 }
+
+// Get latest vehicle state
+CanVehicleState CanInterface::getState() const {
+
+    return current_state_;
+}
+

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -1,0 +1,6 @@
+#include "drivers/can_interface.hpp"
+
+#include <iostream>
+#include <cstring>
+#include <sstream>
+#include <iomanip>

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -14,3 +14,23 @@
 #include <linux/can/raw.h>
 #include <fcntl.h>
 
+
+namespace autoware_pov::drivers {
+
+CanInterface::CanInterface(
+    const std::string& interface_name
+) {
+
+    // If file path (.asc) : file replay
+    if (interface_name.find(".asc") != std::string::npos) {
+        std::cout << "[CanInterface] Detected .asc file extension. Initializing file replay mode: " 
+                  << interface_name << std::endl;
+        setupFile(interface_name);
+    } 
+    // Else : real-time inference via SocketCAN
+    else {
+        std::cout << "[CanInterface] Initializing real-time inference mode (SocketCAN): " 
+                  << interface_name << std::endl;
+        setupSocket(interface_name);
+    }
+}

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -223,10 +223,29 @@ bool CanInterface::readSocket() {
 void CanInterface::setupFile(
     const std::string& file_path
 ) {
-    
+
     is_file_mode_ = true;
     file_stream_.open(file_path);
     if (!file_stream_.is_open()) {
         std::cerr << "[CanInterface] Failed to open file: " << file_path << std::endl;
     }
 }
+
+bool CanInterface::readFileLine() {
+
+    if (!file_stream_.is_open()) return false;
+
+    std::string line;
+    // We assume update() is called frequently.
+    // We read ONE line per update to simulate a stream.
+    // In a real replay tool we'd respect timestamps.
+    // But for simple integration testing, line-by-line is sufficient.
+    
+    if (std::getline(file_stream_, line)) {
+        std::istringstream iss(line);
+        std::string token;
+        std::vector<std::string> parts;
+        
+        while (iss >> token) {
+            parts.push_back(token);
+        }

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -91,3 +91,20 @@ void CanInterface::parseFrame(
         current_state_.is_valid = true;
     }
 }
+
+// ABSSP1 (Speed) : Start Bit 39 | Length 16 | Signed | Factor 0.01
+// Format: Motorola (Big Endian: https://en.wikipedia.org/wiki/Endianness)
+// Bit 39 is in byte 4. (0-indexed). 
+// 16 bits -> spans byte 4 (high) and byte 5 (low) or 4 and 3?
+// We assume [byte 4] is MSB, [byte 5] is LSB based on standard layout.
+double CanInterface::decodeSpeed(const std::vector<uint8_t>& data) {
+
+    if (data.size() < 8) return 0.0;
+
+    // Combine byte 4 and byte 5
+    // Note: DBC bit numbering can be tricky. If start is 39 (0x27), that is bit 7 of byte 4.
+    // We assume standard Big Endian placement.
+    int16_t raw = (static_cast<int16_t>(data[4]) << 8) | static_cast<int16_t>(data[5]);
+    
+    return static_cast<double>(raw) * 0.01;
+}

--- a/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
+++ b/VisionPilot/Production_Releases/0.5/src/drivers/can_interface.cpp
@@ -4,3 +4,13 @@
 #include <cstring>
 #include <sstream>
 #include <iomanip>
+
+// Linux SocketCAN headers
+#include <unistd.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <fcntl.h>
+


### PR DESCRIPTION
This module features C++ interface for reading vehicle telemetry (speed + steering angle) from the CAN bus. I designed it in a way that it supports both real-time live vehicle and file replay (like when you stick a `.asc` test file to it) :

- Real-time inference: connects to physical CAN bus via Linux SocketCAN (like `can0`). 
- File replay: accepts a path to a `.asc` log file, for testing only.

