### PR TITLE
Fix GHCR push permission error

### DIFF
--- a/.github/workflows/build-visionpilot-container.yaml
+++ b/.github/workflows/build-visionpilot-container.yaml
@@ -79,6 +79,11 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     steps:
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Added autoware git config to fix the **permission error while pushing to GHCR**: `buildx failed with: ERROR: failed to build: failed to solve: failed to push ghcr.io/autowarefoundation/visionpilot:1d52587578651cab904d46ddca96200e025e6571-arm64: denied: installation not allowed to Create organization package` . 

[Example workflow run](https://github.com/autowarefoundation/autoware.privately-owned-vehicles/actions/runs/20220564057/job/58041658237#step:6:6029) 