### PR TITLE
ci: add permissions to push image

### DIFF
--- a/.github/workflows/build-visionpilot-container.yaml
+++ b/.github/workflows/build-visionpilot-container.yaml
@@ -20,6 +20,11 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     strategy:
       matrix:
         platform: [amd64, arm64]
@@ -47,7 +52,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -57,7 +62,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
-      
+
       - name: Build VisionPilot container
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
This updates the workflow for docker images to have the access to write to visionpilot package in the autowarefoundation 
https://github.com/autowarefoundation/autoware.privately-owned-vehicles/pkgs/container/visionpilot/versions