### PR TITLE
ci: apply permission to top-level to apply for all jobs

### DIFF
--- a/.github/workflows/build-visionpilot-container.yaml
+++ b/.github/workflows/build-visionpilot-container.yaml
@@ -18,13 +18,13 @@ on:
       - 'Modules/**'
       - 'VisionPilot/**'
 
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 jobs:
   build:
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
     strategy:
       matrix:
         platform: [amd64, arm64]


### PR DESCRIPTION
Currently, Build VisionPilot Container workflow is failing at manifest job.([example](https://github.com/autowarefoundation/autoware.privately-owned-vehicles/actions/runs/20340533851)) This PR updates the permission to be applied to whole jobs to remove the issue.