### PR TITLE
Fix tensor mismatch in video visualization of EgoLanes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,8 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# VisionPilot specific
+3rdparty/
+trt_cache/
+assets/

--- a/Models/visualizations/EgoLanes/video_visualization.py
+++ b/Models/visualizations/EgoLanes/video_visualization.py
@@ -82,7 +82,6 @@ def main():
 
         # Inference
         prediction = model.inference(image)
-        prediction = np.moveaxis(prediction, 0, -1)
 
         # Frame preprocessing
         vis_image_data = make_visualization(image.copy(), prediction)


### PR DESCRIPTION
Fixed a tensor dimension mismatch in `Models/visualizations/EgoLanes/video_visualization.py` that was causing lane predictions to appear as vertical streaks.

### 1. Issues

Someone tried EgoLanes inference from the Python source. While image inference results were good, video inference appeared to output lane markings as vertical streaks instead of laying on the streets.

<img width="1351" height="666" alt="image" src="https://github.com/user-attachments/assets/cea683be-ad0f-4d8b-bffa-85064a69ab90" />

### 2. Culprits

Turned out in the `video_visualization.py` module there was a line:

```python3

# Inference
prediction = model.inference(image)
prediction = np.moveaxis(prediction, 0, -1)

```

That `np.moveaxis()` line projects model output from `(C, H, W)` to `(H, W, C)`, and the rest of the vis pipeline turn them into those vertical streaks.

### 3. Solutions

Simply remove that line. Now everything is good.

<img width="596" height="297" alt="image" src="https://github.com/user-attachments/assets/bce25ced-2993-427b-b41e-bcdd824d8fc4" />