### PR TITLE
fix: egolanes visualization format update

### DIFF
--- a/Models/visualizations/EgoLanes/image_visualization.py
+++ b/Models/visualizations/EgoLanes/image_visualization.py
@@ -40,6 +40,8 @@ def make_visualization(
         (0, 153, 0),        # Green     (other lanes)
     ]
 
+    overlay = img_bgr.copy()
+
     # Draw
     for i, (ys, xs) in enumerate(pred_coords):
         if ys.size == 0:

--- a/Models/visualizations/EgoLanes/image_visualization.py
+++ b/Models/visualizations/EgoLanes/image_visualization.py
@@ -10,7 +10,8 @@ from inference.ego_lanes_infer import EgoLanesNetworkInfer
     
 def make_visualization(
         image: np.ndarray,
-        prediction: np.ndarray
+        prediction: np.ndarray,
+        alpha: float = 0.5
 ):
     
     # Compute scale from prediction to image
@@ -34,7 +35,7 @@ def make_visualization(
 
     # Color codes (RGB)
     colors = [
-        (0, 72, 255),        # Blue      (ego left)
+        (0, 72, 255),       # Blue      (ego left)
         (200, 0, 255),      # Magenta   (ego right)
         (0, 153, 0),        # Green     (other lanes)
     ]

--- a/Models/visualizations/EgoLanes/image_visualization.py
+++ b/Models/visualizations/EgoLanes/image_visualization.py
@@ -8,6 +8,9 @@ sys.path.append('../..')
 from inference.ego_lanes_infer import EgoLanesNetworkInfer
 
     
+FRAME_INF_SIZE = (640, 320)
+
+
 def make_visualization(
         image: np.ndarray,
         prediction: np.ndarray,
@@ -137,7 +140,7 @@ def main():
 
             print(f"Reading Image: {input_image_filepath}")
             image = Image.open(input_image_filepath).convert("RGB")
-            image = image.resize((640, 320))
+            image = image.resize(FRAME_INF_SIZE)
             image = np.array(image)
 
             # Inference

--- a/Models/visualizations/EgoLanes/image_visualization.py
+++ b/Models/visualizations/EgoLanes/image_visualization.py
@@ -14,7 +14,7 @@ FRAME_INF_SIZE = (640, 320)
 def make_visualization(
         image: np.ndarray,
         prediction: np.ndarray,
-        alpha: float = 0.7
+        alpha: float = 0.5
 ):
     
     # Compute scale from prediction to image
@@ -36,11 +36,11 @@ def make_visualization(
     base_scale = min(scale_x, scale_y)
     radius = max(1, int(round(base_scale * 0.5)))
 
-    # Color codes (RGB)
+    # Color codes (BGR)
     colors = [
-        (166, 242, 255),     # Light blue
-        (255, 166, 242),     # Light purple
-        (167, 255, 166),     # Light green
+        (255, 0, 0),     # Blue
+        (255, 0, 255),   # Magenta
+        (0, 255, 0),     # Green
     ]
 
     overlay = np.zeros_like(img_bgr)
@@ -71,7 +71,10 @@ def make_visualization(
     # Blend
     if (alpha > 0.0):
         img_bgr = np.clip(
-            img_bgr.astype(np.float32) + overlay.astype(np.float32) * alpha,
+            (
+                img_bgr.astype(np.float32) + 
+                overlay.astype(np.float32) * alpha
+            ),
             0,
             255
         ).astype(np.uint8)

--- a/Models/visualizations/EgoLanes/image_visualization.py
+++ b/Models/visualizations/EgoLanes/image_visualization.py
@@ -14,7 +14,7 @@ FRAME_INF_SIZE = (640, 320)
 def make_visualization(
         image: np.ndarray,
         prediction: np.ndarray,
-        alpha: float = 0.5
+        alpha: float = 0.7
 ):
     
     # Compute scale from prediction to image
@@ -38,12 +38,12 @@ def make_visualization(
 
     # Color codes (RGB)
     colors = [
-        (0, 72, 255),       # Blue      (ego left)
-        (200, 0, 255),      # Magenta   (ego right)
-        (0, 153, 0),        # Green     (other lanes)
+        (166, 242, 255),     # Light blue
+        (255, 166, 242),     # Light purple
+        (167, 255, 166),     # Light green
     ]
 
-    overlay = img_bgr.copy()
+    overlay = np.zeros_like(img_bgr)
 
     # Draw
     for i, (ys, xs) in enumerate(pred_coords):
@@ -57,7 +57,7 @@ def make_visualization(
         ys_scaled = np.clip(ys_scaled, 0, img_h - 1)
 
         # Draw dots
-        color = colors[i] if i < len(colors) else (255, 255, 255)
+        color = colors[i]
         for x, y in zip(xs_scaled, ys_scaled):
             cv2.circle(
                 overlay, 
@@ -68,19 +68,13 @@ def make_visualization(
                 lineType = cv2.LINE_AA
             )
 
-    if (0.0 < alpha < 1.0):
-        diff_mask = np.any(
-            overlay != img_bgr, 
-            axis = 2
-        )
-        if (np.any(diff_mask)):
-            blended = (
-                overlay.astype(np.float32) * alpha +
-                img_bgr.astype(np.float32) * (1.0 - alpha)
-            )
-            img_bgr[diff_mask] = blended[diff_mask].astype(np.uint8)
-    else:
-        img_bgr = overlay
+    # Blend
+    if (alpha > 0.0):
+        img_bgr = np.clip(
+            img_bgr.astype(np.float32) + overlay.astype(np.float32) * alpha,
+            0,
+            255
+        ).astype(np.uint8)
     
     # Back to PIL Image
     vis_image = Image.fromarray(cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB))

--- a/Models/visualizations/EgoLanes/image_visualization.py
+++ b/Models/visualizations/EgoLanes/image_visualization.py
@@ -57,13 +57,15 @@ def make_visualization(
         ys_scaled = np.clip(ys_scaled, 0, img_h - 1)
 
         # Draw dots
-        color = colors[i] if i < len(colors) else (255,255,255)
+        color = colors[i] if i < len(colors) else (255, 255, 255)
         for x, y in zip(xs_scaled, ys_scaled):
             cv2.circle(
                 overlay, 
                 (int(x), int(y)), 
-                radius, color, thickness = -1, 
-                lineType=cv2.LINE_AA
+                radius, 
+                color, 
+                thickness = -1, 
+                lineType = cv2.LINE_AA
             )
 
     if (0.0 < alpha < 1.0):

--- a/Models/visualizations/EgoLanes/image_visualization.py
+++ b/Models/visualizations/EgoLanes/image_visualization.py
@@ -38,9 +38,9 @@ def make_visualization(
 
     # Color codes (BGR)
     colors = [
-        (255, 0, 0),     # Blue
-        (255, 0, 255),   # Magenta
-        (0, 255, 0),     # Green
+        (255, 153, 0),     # Blue
+        (255, 56, 255),   # Magenta
+        (87, 255, 87),     # Green
     ]
 
     overlay = np.zeros_like(img_bgr)

--- a/Models/visualizations/EgoLanes/image_visualization.py
+++ b/Models/visualizations/EgoLanes/image_visualization.py
@@ -57,12 +57,26 @@ def make_visualization(
         color = colors[i] if i < len(colors) else (255,255,255)
         for x, y in zip(xs_scaled, ys_scaled):
             cv2.circle(
-                img_bgr, 
+                overlay, 
                 (int(x), int(y)), 
                 radius, color, thickness = -1, 
                 lineType=cv2.LINE_AA
             )
 
+    if (0.0 < alpha < 1.0):
+        diff_mask = np.any(
+            overlay != img_bgr, 
+            axis = 2
+        )
+        if (np.any(diff_mask)):
+            blended = (
+                overlay.astype(np.float32) * alpha +
+                img_bgr.astype(np.float32) * (1.0 - alpha)
+            )
+            img_bgr[diff_mask] = blended[diff_mask].astype(np.uint8)
+    else:
+        img_bgr = overlay
+    
     # Back to PIL Image
     vis_image = Image.fromarray(cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB))
 

--- a/Models/visualizations/EgoLanes/image_visualization.py
+++ b/Models/visualizations/EgoLanes/image_visualization.py
@@ -56,17 +56,17 @@ def make_visualization(
         xs_scaled = np.clip(xs_scaled, 0, img_w - 1)
         ys_scaled = np.clip(ys_scaled, 0, img_h - 1)
 
-        # Draw dots
+        # Draw points
         color = colors[i]
         for x, y in zip(xs_scaled, ys_scaled):
-            cv2.circle(
-                overlay, 
-                (int(x), int(y)), 
-                radius, 
-                color, 
-                thickness = -1, 
-                lineType = cv2.LINE_AA
-            )
+            x0 = max(0, int(x) - radius)
+            x1 = min(img_w - 1, int(x) + radius)
+            y0 = max(0, int(y) - radius)
+            y1 = min(img_h - 1, int(y) + radius)
+            overlay[
+                y0 : y1 + 1, 
+                x0 : x1 + 1
+            ] = color
 
     # Blend
     if (alpha > 0.0):


### PR DESCRIPTION
This PR addresses ticket #239 .

Now the result for EgoLanes inference looks like this.

<img width="640" height="320" alt="010_data" src="https://github.com/user-attachments/assets/e217b0ed-22d3-4ff0-8d87-84558b223235" />

Basically the one format used for VisionPilot but we kinda forgot to apply that to corresponding Python modules. Now it's here.