### PR TITLE
fix: correct argparse variable names in DomainSeg video_visualization

### DIFF
--- a/Models/visualizations/DomainSeg/video_visualization.py
+++ b/Models/visualizations/DomainSeg/video_visualization.py
@@ -75,11 +75,11 @@ def main():
     
   # Create a VideoCapture object and read from input file
   # If the input is taken from the camera, pass 0 instead of the video file name.
-  video_filepath = args.video_filepath
+  video_filepath = args.input_video_filepath
   cap = cv2.VideoCapture(video_filepath)
 
   # Output filepath
-  output_filepath_obj = args.output_file + ".avi"
+  output_filepath_obj = args.output_video_filepath + ".avi"
   fps = cap.get(cv2.CAP_PROP_FPS)
   # Video writer object
   writer_obj = cv2.VideoWriter(


### PR DESCRIPTION
This PR fixes a variable name mismatch in
Models/visualizations/DomainSeg/video_visualization.py.

The argparse definitions specify the following destinations:

- input_video_filepath
- output_video_filepath

However, the script references non-existent attributes:

- args.video_filepath
- args.output_file

This results in an AttributeError when running the script.

This patch updates the variable references to match the argparse
definitions:

- args.video_filepath → args.input_video_filepath
- args.output_file → args.output_video_filepath









