### PR TITLE
fix: fix egolanes Python imports and Podman compatibility

### DIFF
--- a/Models/inference/ego_lanes_infer.py
+++ b/Models/inference/ego_lanes_infer.py
@@ -1,8 +1,6 @@
 import torch
 from torchvision import transforms
-import sys
-sys.path.append("..")
-from model_components.ego_lanes_network import EgoLanesNetwork
+from Models.model_components.ego_lanes_network import EgoLanesNetwork
 
 
 class EgoLanesNetworkInfer():

--- a/Models/visualizations/EgoLanes/video_visualization.py
+++ b/Models/visualizations/EgoLanes/video_visualization.py
@@ -5,8 +5,7 @@ import numpy as np
 from tqdm import tqdm
 from PIL import Image, ImageDraw
 from argparse import ArgumentParser
-sys.path.append('../..')
-from inference.ego_lanes_infer import EgoLanesNetworkInfer
+from Models.inference.ego_lanes_infer import EgoLanesNetworkInfer
 from image_visualization import make_visualization
 
 FRAME_INF_SIZE = (640, 320)

--- a/VisionPilot/software_defined_vehicle/OpenADKit/EgoLanes/README.md
+++ b/VisionPilot/software_defined_vehicle/OpenADKit/EgoLanes/README.md
@@ -21,6 +21,8 @@ Containerized EgoLanes Demo, semantic segmentation of driving lanes.
 
 After the container is running, you can access the visualization by opening the following URL in your browser:
 
-<http://localhost:6080/vnc.html?resize=scale&autoconnect=true&password=visualizer>
+<http://127.0.0.1:6080/vnc.html?resize=scale&autoconnect=true&password=visualizer>
+
+> **Note:** Use `127.0.0.1` instead of `localhost`. On systems where `localhost` resolves to IPv6 (`::1`), the connection will fail as Podman's `pasta` network backend only handles IPv4.
 
 The output shows semantic segmentation of the driving lanes of the input video in real-time.

--- a/VisionPilot/software_defined_vehicle/OpenADKit/EgoLanes/launch-egolanes.sh
+++ b/VisionPilot/software_defined_vehicle/OpenADKit/EgoLanes/launch-egolanes.sh
@@ -3,7 +3,8 @@
 # Run the container
 docker run -it --rm \
     -p 6080:6080 \
-    -v "$PWD"/model-weights:/autoware/model-weights \
-    -v "$PWD"/../Test:/autoware/test \
+    -v "$PWD"/model-weights:/autoware/model-weights:z \
+    -v "$PWD"/../Test:/autoware/test:z \
+    -e PYTHONPATH=/autoware \
     ghcr.io/autowarefoundation/visionpilot:latest \
     python3 /autoware/Models/visualizations/EgoLanes/video_visualization.py -v -p /autoware/model-weights/egolanes.pth -i /autoware/test/traffic-driving.mp4 -o /autoware/test/output_egolanes.avi


### PR DESCRIPTION
- Remove sys.path.append hacks, use consistent Models.* import paths
- Add :z to volume mounts to fix SELinux blocking container file access
- Add missing PYTHONPATH=/autoware required for Models.* imports to resolve
- Replace localhost with 127.0.0.1 to fix IPv6 resolution issue with Podman pasta backend"

Assisted-By: Claude