### PR TITLE
fix(autospeed): fix Podman compatibility and improve build docs

### DIFF
--- a/VisionPilot/middleware_recipes/Standalone/AutoSpeed/README.md
+++ b/VisionPilot/middleware_recipes/Standalone/AutoSpeed/README.md
@@ -24,8 +24,18 @@ Multi-threaded inference pipeline with ONNX Runtime (CPU/TensorRT) for real-time
 
 3. **Dependencies**
    - OpenCV 4.x
-   - GStreamer 1.0
+   - GStreamer 1.0 (including `gstreamer-app-1.0`)
    - yaml-cpp
+
+   **Fedora/RHEL:**
+   ```bash
+   sudo dnf install opencv-devel gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-good yaml-cpp-devel cmake gcc-c++
+   ```
+
+   **Debian/Ubuntu:**
+   ```bash
+   sudo apt install libopencv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good libyaml-cpp-dev cmake g++
+   ```
 
 ### Build Steps
 

--- a/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/README.md
+++ b/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/README.md
@@ -21,6 +21,8 @@ Containerized AutoSpeed Demo, closest in-path object detection and tracking.
 
 After the container is running, you can access the visualization by opening the following URL in your browser:
 
-<http://localhost:6080/vnc.html?resize=scale&autoconnect=true&password=visualizer>
+<http://127.0.0.1:6080/vnc.html?resize=scale&autoconnect=true&password=visualizer>
+
+> **Note:** Use `127.0.0.1` instead of `localhost`. On systems where `localhost` resolves to IPv6 (`::1`), the connection will fail as Podman's `pasta` network backend only handles IPv4.
 
 The output shows closest in-path object detection and tracking of the input video in real-time.

--- a/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/launch_autospeed.sh
+++ b/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/launch_autospeed.sh
@@ -3,8 +3,8 @@
 # Run the container
 docker run -it --rm \
     -p 6080:6080 \
-    -v "$PWD"/model-weights:/autoware/model-weights \
-    -v "$PWD"/launch:/autoware/launch \
+    -v "$PWD"/model-weights:/autoware/model-weights:z \
+    -v "$PWD"/launch:/autoware/launch:z \
     -v "$PWD"/../Test:/autoware/test \
     ghcr.io/autowarefoundation/visionpilot:latest \
     /autoware/launch/run_objectFinder.sh


### PR DESCRIPTION
- Add :z to volume mounts to fix SELinux blocking container file access
- Replace localhost with 127.0.0.1 to fix IPv6 resolution issue with Podman pasta backend
- Add concrete package install commands to standalone README
- Document gstreamer-app-1.0 as a separate required dependency"

Assisted-By: Claude