### PR TITLE
feat: enable autospeed gpu inference with tensorrt

### DIFF
--- a/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/README.md
+++ b/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/README.md
@@ -17,6 +17,64 @@ Containerized AutoSpeed Demo, closest in-path object detection and tracking.
 ./launch-autospeed.sh
 ```
 
+## GPU Usage (TensorRT)
+
+Running with GPU acceleration requires additional setup on the host before launching the container.
+
+### Host Prerequisites
+
+1. **NVIDIA drivers + CUDA** installed on the host
+
+2. **podman** and **nvidia-container-toolkit** with CDI configured:
+   ```bash
+   dnf install -y podman nvidia-container-toolkit
+   nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+   ```
+
+3. **ONNX Runtime 1.22.0 GPU** — the container ships CPU-only, GPU version must be provided externally:
+   ```bash
+   wget https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-gpu-1.22.0.tgz
+   tar -xzf onnxruntime-linux-x64-gpu-1.22.0.tgz -C /root/
+   ```
+
+4. **CUDA 12 libraries** — ONNX Runtime 1.22.0 requires CUDA 12 even if host has CUDA 13:
+   ```bash
+   dnf install -y cuda-libraries-12-9
+   mkdir -p /root/cuda12-lib
+   find /usr/local/cuda-12.9/targets/x86_64-linux/lib -name "*.so.*" \
+       -exec cp {} /root/cuda12-lib/ \;
+   find /usr/local/cuda-12.9/targets/x86_64-linux/lib -name "*.so.*" \
+       -type l -exec cp -P {} /root/cuda12-lib/ \;
+   ```
+
+5. **TensorRT 10** — the binary requires TRT 10; install via pip since package repos only provide TRT 11:
+   ```bash
+   pip install tensorrt==10.6.0 --extra-index-url https://pypi.nvidia.com
+   mkdir -p /root/tensorrt-libs
+   cp /usr/local/lib/python3.9/site-packages/tensorrt_libs/*.so* /root/tensorrt-libs/
+   ```
+
+6. **cuDNN 9**:
+   ```bash
+   dnf install -y libcudnn9-cuda-13
+   mkdir -p /root/cudnn-lib
+   cp /usr/lib64/libcudnn*.so.9* /root/cudnn-lib/
+   ```
+
+7. **TRT engine cache directory**:
+   ```bash
+   mkdir -p /root/trt_cache
+   ```
+
+### Running with GPU
+
+```bash
+./launch_autospeed.sh
+```
+
+On first run, the TRT engine is built and cached (~30 seconds). Subsequent runs start immediately.
+
+
 ## Output
 
 After the container is running, you can access the visualization by opening the following URL in your browser:
@@ -26,3 +84,9 @@ After the container is running, you can access the visualization by opening the 
 > **Note:** Use `127.0.0.1` instead of `localhost`. On systems where `localhost` resolves to IPv6 (`::1`), the connection will fail as Podman's `pasta` network backend only handles IPv4.
 
 The output shows closest in-path object detection and tracking of the input video in real-time.
+
+**For GPU running on a remote machine:** First set up SSH port forwarding:
+```bash
+ssh -L 6080:localhost:6080 root@<machine-hostname>
+```
+Then open in your browser: `http://127.0.0.1:6080/vnc.html?resize=scale&autoconnect=true&password=visualizer`

--- a/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/launch/run_objectFinder.sh
+++ b/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/launch/run_objectFinder.sh
@@ -7,7 +7,7 @@ export GST_DEBUG=1
 # ===== Required Parameters =====
 VIDEO_PATH="/autoware/test/traffic-driving.mp4"
 MODEL_PATH="/autoware/model-weights/autospeed.onnx"
-PROVIDER="cpu"       # Execution provider: 'cpu' or 'tensorrt'
+PROVIDER="tensorrt"       # Execution provider: 'cpu' or 'tensorrt'
 PRECISION="fp32"     # Precision: 'fp32' or 'fp16' (for TensorRT)
 HOMOGRAPHY_YAML="/autoware/VisionPilot/Middleware_Recipes/Standalone/AutoSpeed/homography.yaml"
 NUM_THREADS="4" # 0 means auto, number of inference threads, 1 thread for capture, 1 thread for display will be used aside from this
@@ -46,10 +46,6 @@ echo "Model: $MODEL_PATH"
 echo "Provider: $PROVIDER"
 echo "Precision: $PRECISION"
 echo "Homography: $HOMOGRAPHY_YAML"
-if [ "$PROVIDER" == "tensorrt" ]; then
-    echo "Device ID: $DEVICE_ID"
-    echo "Cache Dir: $CACHE_DIR"
-fi
 echo "========================================"
 echo "Visualization: $ENABLE_VIZ"
 echo "Save Video: $SAVE_VIDEO"
@@ -72,4 +68,9 @@ if [ -z "$ONNXRUNTIME_ROOT" ]; then
     exit 1
 fi
 
+if [ "$PROVIDER" == "tensorrt" ] && [ -z "$(ls -A $CACHE_DIR/*.engine 2>/dev/null)" ]; then
+    echo "[warm-up] Building TensorRT engine cache (first run only, ~30s)..."
+    timeout 120 /autoware/autospeed_infer_stream "$VIDEO_PATH" "$MODEL_PATH" "$PROVIDER" "$PRECISION" "$HOMOGRAPHY_YAML" "$DEVICE_ID" "$CACHE_DIR" "false" "false" "false" "false" "$OUTPUT_VIDEO" "$NUM_THREADS" > /dev/null 2>&1 || true
+    echo "[warm-up] Done. Starting inference..."
+fi
 /autoware/autospeed_infer_stream "$VIDEO_PATH" "$MODEL_PATH" "$PROVIDER" "$PRECISION" "$HOMOGRAPHY_YAML" "$DEVICE_ID" "$CACHE_DIR" "$REALTIME" "$MEASURE_LATENCY" "$ENABLE_VIZ" "$SAVE_VIDEO" "$OUTPUT_VIDEO" "$NUM_THREADS"

--- a/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/launch_autospeed.sh
+++ b/VisionPilot/software_defined_vehicle/OpenADKit/AutoSpeed/launch_autospeed.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
-
-# Run the container
-docker run -it --rm \
+podman run -it --rm \
+    --device nvidia.com/gpu=all \
     -p 6080:6080 \
+    -e DISPLAY=:99 \
+    -e ONNXRUNTIME_ROOT=/onnxruntime \
+    -e LD_LIBRARY_PATH=/onnxruntime/lib:/cuda12-lib:/tensorrt10-lib:/cudnn-lib \
+    -v /root/onnxruntime-linux-x64-gpu-1.22.0:/onnxruntime:z \
+    -v /root/cuda12-lib:/cuda12-lib:z \
+    -v /root/tensorrt-libs:/tensorrt10-lib:z \
+    -v /root/cudnn-lib:/cudnn-lib:z \
+    -v /root/trt_cache:/autoware/trt_cache:z \
     -v "$PWD"/model-weights:/autoware/model-weights:z \
     -v "$PWD"/launch:/autoware/launch:z \
-    -v "$PWD"/../Test:/autoware/test \
+    -v "$PWD"/../Test:/autoware/test:z \
     ghcr.io/autowarefoundation/visionpilot:latest \
     /autoware/launch/run_objectFinder.sh


### PR DESCRIPTION
The AutoSpeed container ships with CPU-only ONNX Runtime. This change:
- Enables GPU inference by mounting external GPU libraries (ONNX Runtime 1.22.0 GPU, CUDA 12, TensorRT 10, cuDNN 9) into the container via Podman volume mounts.
- Switches from Docker to Podman and adds GPU passthrough via CDI.
- Fixes a first-run failure where TensorRT engine building (~30s) competed with GStreamer video capture, causing the pipeline to fail. A warm-up step pre-builds the TRT engine cache before the main run.

Assisted-By: Claude