### PR TITLE
feat: enable EgoLanes GPU inference with PyTorch CUDA

### DIFF
--- a/VisionPilot/software_defined_vehicle/OpenADKit/EgoLanes/README.md
+++ b/VisionPilot/software_defined_vehicle/OpenADKit/EgoLanes/README.md
@@ -26,3 +26,32 @@ After the container is running, you can access the visualization by opening the 
 > **Note:** Use `127.0.0.1` instead of `localhost`. On systems where `localhost` resolves to IPv6 (`::1`), the connection will fail as Podman's `pasta` network backend only handles IPv4.
 
 The output shows semantic segmentation of the driving lanes of the input video in real-time.
+
+## GPU Usage (PyTorch CUDA)
+
+Running with GPU acceleration requires minimal additional setup — the container already ships with CUDA-enabled PyTorch that auto-detects the GPU automatically.
+
+### Host Prerequisites
+
+1. **NVIDIA drivers + CUDA** installed on the host
+
+2. **podman** and **nvidia-container-toolkit** with CDI configured:
+   ```bash
+   dnf install -y podman nvidia-container-toolkit
+   nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+   ```
+
+### Running with GPU
+
+**Note:** Open the browser BEFORE running — EgoLanes processes fast and will finish before you can connect if opened after.
+
+**For GPU running on a remote machine:** First set up SSH port forwarding:
+```bash
+ssh -L 6080:localhost:6080 root@<machine-hostname>
+```
+Then open in your browser: `http://127.0.0.1:6080/vnc.html?resize=scale&autoconnect=true&password=visualizer`
+
+Then run:
+```bash
+./launch-egolanes.sh
+```

--- a/VisionPilot/software_defined_vehicle/OpenADKit/EgoLanes/launch-egolanes.sh
+++ b/VisionPilot/software_defined_vehicle/OpenADKit/EgoLanes/launch-egolanes.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 # Run the container
-docker run -it --rm \
+podman run -it --rm \
+    --device nvidia.com/gpu=all \
     -p 6080:6080 \
     -v "$PWD"/model-weights:/autoware/model-weights:z \
     -v "$PWD"/../Test:/autoware/test:z \
-    -e PYTHONPATH=/autoware \
+    -e PYTHONPATH=/autoware:/autoware/Models \
     ghcr.io/autowarefoundation/visionpilot:latest \
     python3 /autoware/Models/visualizations/EgoLanes/video_visualization.py -v -p /autoware/model-weights/egolanes.pth -i /autoware/test/traffic-driving.mp4 -o /autoware/test/output_egolanes.avi


### PR DESCRIPTION
The EgoLanes container ships with CUDA-enabled PyTorch (2.11.0+cu130) that auto-detects the GPU via torch.cuda.is_available(). This change enables GPU inference with minimal setup:
- Switches from Docker to Podman and adds GPU passthrough via CDI.
- Fixes a Python import error by adding /autoware/Models to PYTHONPATH.

Assisted-By: Claude