### PR TITLE
fix: use VehicleRos2Node name in vehicle ROS2 interface

### DIFF
--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/src/vehicle_ros2_interface.cpp
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/src/vehicle_ros2_interface.cpp
@@ -1,6 +1,6 @@
 #include <vehicle_ros2_interface/vehicle_ros2_interface.hpp>
 
-VehicleRos2Interface::Ros2Node::Ros2Node()
+VehicleRos2Interface::VehicleRos2Node::VehicleRos2Node()
     : rclcpp::Node("vehicle_ros2_interface")
 {
     // pub_ = create_publisher<...>(...);
@@ -9,7 +9,7 @@ VehicleRos2Interface::Ros2Node::Ros2Node()
 
 VehicleRos2Interface::VehicleRos2Interface()
 {
-    node_ = std::make_shared<Ros2Node>(); // node exists as shared_ptr
+    node_ = std::make_shared<VehicleRos2Node>(); // node exists as shared_ptr
     executor_.add_node(node_); // no shared_from_this needed
     spin_thread_ = std::thread([this]() { executor_.spin(); });
 }


### PR DESCRIPTION
## What

Building VisionPilot 1.0 with `-DENABLE_ROS2_INTERFACE=ON` fails to compile.
The vehicle ROS2 interface source used a class name `Ros2Node` that does not
exist. The header declares the inner class as `VehicleRos2Node`.

This renames the two references in the source to match the header.

## Why it was not caught

The default build is `-DENABLE_ROS2_INTERFACE=OFF`, so the ROS2 interface is
not compiled. Only the ROS2 ON build hits this.

## Change

`VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/src/vehicle_ros2_interface.cpp`

```diff
-VehicleRos2Interface::Ros2Node::Ros2Node()
+VehicleRos2Interface::VehicleRos2Node::VehicleRos2Node()

-    node_ = std::make_shared<Ros2Node>();
+    node_ = std::make_shared<VehicleRos2Node>();
```

Introduced by commit f0cb74482.

Closes #337
