### PR TITLE
fix: build breaks on Ubuntu 24.04 / ROS 2 Jazzy (OpenCV 4.6-4.12)

### DIFF
--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_subscriber/include/camera_subscriber/ros2_to_opencv.hpp
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_subscriber/include/camera_subscriber/ros2_to_opencv.hpp
@@ -3,7 +3,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/opencv.hpp>
 #include <cstdint>
 #include <memory>

--- a/VisionPilot/scripts/find_homography_C_matrix.py
+++ b/VisionPilot/scripts/find_homography_C_matrix.py
@@ -23,7 +23,7 @@ V = np.array(
 
 def load_homography_H_matrix(path: Path) -> np.ndarray:
     # Load the homography matrix from the YAML file
-    fs = cv2.FileStorage(path, cv2.FILE_STORAGE_READ)
+    fs = cv2.FileStorage(str(path), cv2.FILE_STORAGE_READ)
     H = fs.getNode("H").mat()
     fs.release()
     return H


### PR DESCRIPTION
## Summary

The tree fails to build on a clean Ubuntu 24.04 / ROS 2 Jazzy setup. This fixes three breaks so it compiles, both with ENABLE_ROS2_INTERFACE OFF and ON. Validated on OpenCV 4.6 (apt default) and 4.12.0 (latest 4.x).

## Fixes

1. scripts/find_homography_C_matrix.py: pass str() to cv2.FileStorage. OpenCV 4.6 rejects a Path object (4.12 accepts it). The write side already used str().
2. app/vision_pilot.cpp: cfg_path was removed when config loading went zero-config, but the debug overlay call still used it. Pass a source label instead. No behavior change.
3. ros2_to_opencv.hpp: include cv_bridge/cv_bridge.hpp. The old .h header was dropped in Jazzy; .hpp also works on Humble.

## How we found it

Building in a clean container (Ubuntu 24.04, Jazzy) instead of a pre-populated host. The OFF build stopped at 1 then 2; the ON build also stopped at 3.

## Verification

Both builds compile all targets including the VisionPilot binary, and test_planning passes. Rechecked in the dev container on OpenCV 4.12.0, OFF and ON.
