### PR TITLE
feat: Send frame size directly, instead via image_preprocessor

### DIFF
--- a/VisionPilot/modules/sensing/image_preprocessing/include/image_preprocessing/image_preprocessor.hpp
+++ b/VisionPilot/modules/sensing/image_preprocessing/include/image_preprocessing/image_preprocessor.hpp
@@ -9,17 +9,14 @@ public:
 
     ~ImagePreprocessor() = default;
 
-    void preprocess(const cv::Mat &image, cv::Mat &warped_image, cv::Mat &resized_image, const cv::Size &size);
+    void preprocess(const cv::Mat &image, cv::Mat &warped_image, cv::Mat &resized_image, const cv::Size &size) const;
 
     // C maps raw camera pixel → warped 1024×512 BEV (perspective transform).
     const cv::Mat& C_mat()   const { return C; }
-    // Raw frame dimensions seen on the last preprocess() call.
-    cv::Size       raw_size() const { return raw_size_; }
 
 private:
     std::string homography_C_matrix_path;
-    cv::Mat     C;
-    cv::Size    raw_size_;
+    cv::Mat C;
 };
 
 #endif //VISIONPILOT_IMAGE_PREPROCESSOR_HPP

--- a/VisionPilot/modules/sensing/image_preprocessing/src/image_preprocessor.cpp
+++ b/VisionPilot/modules/sensing/image_preprocessing/src/image_preprocessor.cpp
@@ -10,8 +10,7 @@ ImagePreprocessor::ImagePreprocessor() : homography_C_matrix_path("config/homogr
 }
 
 void ImagePreprocessor::preprocess(const cv::Mat &image, cv::Mat &warped_image, cv::Mat &resized_image,
-                                   const cv::Size &size) {
-    raw_size_ = image.size();
+                                   const cv::Size &size) const {
     cv::warpPerspective(image, warped_image, C, cv::Size(1024, 512), cv::INTER_LINEAR,
                         cv::BORDER_REFLECT_101);
     cv::resize(image, resized_image, size);


### PR DESCRIPTION
Send frame size directly, instead via image_preprocessor