### PR TITLE
V0.9.5

### DIFF
--- a/VisionPilot/modules/common/include/common/utils.hpp
+++ b/VisionPilot/modules/common/include/common/utils.hpp
@@ -1,11 +1,21 @@
 #ifndef VISIONPILOT_UTILS_HPP
 #define VISIONPILOT_UTILS_HPP
 
+#include <algorithm>
+#include <cmath>
 #include <filesystem>
 #include <opencv2/opencv.hpp>
 
 std::string find_config(const std::string& filename);
 
 cv::Mat load_matrix(const std::string& filename, const std::string& matrix);
+
+// Drop this many rows from the top so the kept band is width × (width/2) → 2:1 aspect.
+// Matches Models/inference/auto_steer_infer.py compute_top_crop_2_1().
+inline int compute_top_crop_2_1(int height, int width)
+{
+    return std::max(0, static_cast<int>(std::lround(
+        static_cast<double>(height) - static_cast<double>(width) / 2.0)));
+}
 
 #endif //VISIONPILOT_UTILS_HPP

--- a/VisionPilot/modules/models/CMakeLists.txt
+++ b/VisionPilot/modules/models/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(models
 # engine provides OnnxEngine + ORT headers/libs transitively
 target_link_libraries(models
     PUBLIC
+        common
         engine
         fusion
         logging

--- a/VisionPilot/modules/models/include/models/inference.hpp
+++ b/VisionPilot/modules/models/include/models/inference.hpp
@@ -64,7 +64,7 @@ public:
     // (non-BEV) image.  Call once after the first preprocess() when using
     // the resized routing.
     //   C        : raw-camera → warped-BEV homography (from ImagePreprocessor)
-    //   raw_size : original frame dimensions before resize
+    //   raw_size : original frame dimensions before top-crop + resize
     void set_H_resized(const cv::Mat& H, cv::Size raw_size);
 
     // H that maps resized-image pixel → world (set after set_H_resized()).

--- a/VisionPilot/modules/models/src/inference.cpp
+++ b/VisionPilot/modules/models/src/inference.cpp
@@ -1,5 +1,6 @@
 #include <models/inference.hpp>
 
+#include <common/utils.hpp>
 #include <logging/logger.hpp>
 
 #include <opencv2/imgproc.hpp>
@@ -104,26 +105,21 @@ static const cv::Matx33d kV(
 void InferencePipeline::set_H_resized(const cv::Mat& H, cv::Size raw_size)
 {
     // H_resized: resized_px → world  (AutoSteer / AutoSpeed path)
-    // Preprocessor: center-crop to 2:1, then resize to 1024×512.
-    //   raw_px = T × resized_px
-    //     u_raw = u_r · (crop_w / 1024)
-    //     v_raw = v_r · (crop_h / 512) + crop_top
-    //   world  = H × raw_px  ⟹  H_resized = H × T
+    // Preprocessor: top-crop to 2:1, then resize → 1024×512.
+    //   u_raw = u_r · (raw_w / 1024)
+    //   v_raw = v_r · (crop_h / 512) + crop_top
+    //   world = H × raw_px  ⟹  H_resized = H × T
     cv::Mat H64;
     H.convertTo(H64, CV_64F);
 
-    const int input_image_w = raw_size.width;
-    const int input_image_h = raw_size.height;
-    const double crop_top   = (input_image_h - input_image_w / 2) / 2.0;
-    const double crop_w     = static_cast<double>(input_image_w);
-    const double crop_h     = static_cast<double>(input_image_h) - 2.0 * crop_top;
-
-    const double sx = crop_w / 1024.0;
+    const int crop_top = compute_top_crop_2_1(raw_size.height, raw_size.width);
+    const double crop_h = static_cast<double>(raw_size.height - crop_top);
+    const double sx = static_cast<double>(raw_size.width) / 1024.0;
     const double sy = crop_h / 512.0;
 
-    const cv::Matx33d T(sx, 0,        0,
-                        0,  sy,  crop_top,
-                        0,   0,        1);
+    const cv::Matx33d T(sx, 0,  0,
+                        0,  sy, static_cast<double>(crop_top),
+                        0,   0, 1);
 
     const cv::Mat H_resized = H64 * cv::Mat(T);
 
@@ -132,8 +128,8 @@ void InferencePipeline::set_H_resized(const cv::Mat& H, cv::Size raw_size)
     H64_inv.convertTo(H_world2resized_, CV_32F);
     lat_fusion_.set_H(H_resized_);
     long_fusion_.set_H(H_resized_);
-    VP_INFO("[Pipeline] H_resized set — raw=%dx%d  crop=%.0fx%.0f  sx=%.4f sy=%.4f  top=%.0f",
-            raw_size.width, raw_size.height, crop_w, crop_h, sx, sy, crop_top);
+    VP_INFO("[Pipeline] H_resized set — raw=%dx%d  top_crop=%d  sx=%.4f sy=%.4f",
+            raw_size.width, raw_size.height, crop_top, sx, sy);
 }
 
 std::optional<InferenceFrameResult> InferencePipeline::process(const cv::Mat& warped,

--- a/VisionPilot/modules/safety_guardian/fusion/include/fusion/lateral_fusion.hpp
+++ b/VisionPilot/modules/safety_guardian/fusion/include/fusion/lateral_fusion.hpp
@@ -77,7 +77,7 @@ public:
         // Measurement 1-sigma
         float meas_noise_cte_m       = 0.15f;   // tighter now that CTE is at x_min (not extrapolated)
         float meas_noise_yaw_rad     = 0.05f;
-        float meas_noise_curv_path   = 0.005f;  // AutoSteer polynomial curvature
+        float meas_noise_curv_path   = 0.008f;  // AutoSteer polynomial curvature
         float meas_noise_curv_ad     = 0.010f;  // AutoDrive curvature (scaled)
 
         // RANSAC polynomial fit
@@ -93,9 +93,31 @@ public:
         // curvature_raw × scale → physical κ [1/m] (CURV_SCALE = 0.21 in training).
         float ad_curvature_scale     = 0.21f;
         int   ransac_min_inliers     = 12;      // reject path fit if fewer inliers
-        float max_abs_cte_m          = 3.0f;    // reject RANSAC fits with |cte| > 3m (full lane width guard)
+        float max_abs_cte_m          = 3.0f;    // reject RANSAC fits with |cte| > 3m
         float curv_x_min_m           = 3.f;     // κ sampled only at waypoint x ≥ this
         float curv_x_max_m           = 25.f;    // κ sampled only at waypoint x ≤ this
+
+        // ── Polynomial-coefficient Kalman smoother (pre-PF stage) ─────────
+        // Smooths the raw RANSAC (a, b, c) polynomial before it drives both
+        // the particle filter inputs AND the visualization path corridor.
+        // This is the primary fix for sudden path jumps during lane merges.
+        // proc noise per second — larger = faster tracking, less smooth.
+        // poly_meas_R_a / R_b: keep moderate — too large and the yellow fused path
+        // lags real curves (sticks to straight-road memory).  poly_meas_R_c stays
+        // large to smooth lateral jumps at merges.
+        float poly_proc_a_s  = 2e-3f;   // curvature coeff [(1/m)/s]
+        float poly_proc_b_s  = 0.08f;   // slope [rad/s] — tracks heading on curves
+        float poly_proc_c_s  = 0.50f;   // lateral offset [m/s] — merge smoothing
+        float poly_meas_R_a  = 4e-4f;   // [(1/m)²]
+        float poly_meas_R_b  = 0.015f;  // [rad²]
+        float poly_meas_R_c  = 0.50f;   // [m²]
+
+        // ── Rao-Blackwellized Kalman smoother (post-PF stage) ──────────────
+        // Second stage: smooths scalar PF outputs (cte, yaw, curvature).
+        float kf_proc_cte_m_s   = 0.50f;   // [m / s]
+        float kf_proc_yaw_rad_s = 0.15f;   // [rad / s]
+        float kf_proc_curv_s    = 0.004f;  // [(1/m) / s]
+        float kf_meas_R_curv_min = 1e-7f;  // post-PF KF curvature meas-noise floor [(1/m)²]
 
         // Same YAML used by LongitudinalFusion (shared config field).
         bool debug = false;
@@ -164,6 +186,32 @@ private:
     float k_eff_n() const;
     void  k_init(float curv);
 
+    // ── Polynomial-coefficient Kalman smoother (pre-PF) ──────────────────────
+    //  Smooths the raw RANSAC (a, b, c) each frame before they feed the PF and
+    //  the visualization.  This eliminates sudden path-corridor jumps at merges.
+    //  State: x = [a, b, c]  (diagonal — 3 independent scalars)
+    //  Process: random-walk  F = I,  Q = diag(q_i² · dt)
+    //  Measurement: H = I,  z = raw RANSAC coefficients,  R = cfg_.poly_meas_R_*
+    struct PolyKF {
+        float x[3] = {};   // [a, b, c]
+        float P[3] = {};   // diagonal covariances
+        bool  init  = false;
+    };
+    void poly_kf_predict(float dt);
+    // z = raw RANSAC [a, b, c]; quality = inliers / ransac_min_inliers
+    void poly_kf_update(float a, float b, float c, float quality);
+
+    // ── Rao-Blackwellized Kalman smoother (post-PF) ───────────────────────────
+    //  Sits after the PF: consumes PF posterior mean + variance as measurement,
+    //  outputs a smoothed [cte, yaw, curvature] estimate.
+    struct KFState {
+        float x[3] = {};   // [cte, yaw, curvature]
+        float P[3] = {};   // diagonal covariances
+        bool  init  = false;
+    };
+    void kf_predict(float dt);
+    void kf_update(const float z[3], const float R[3]);
+
     // ── Shared helpers ────────────────────────────────────────────────────────
     static float gauss_loglik(float z, float mean, float sigma);
 
@@ -180,6 +228,9 @@ private:
 
     std::vector<KParticle>  k_;
     bool                    k_init_  = false;
+
+    PolyKF  poly_kf_;  // Polynomial-coefficient smoother (pre-PF, pre-viz)
+    KFState kf_;       // Rao-Blackwellized scalar smoother (post-PF)
 
     std::mt19937 rng_;
     // DO NOT MODIFY! VisionPilot model-view homography (1024x512 pixel -> world). Zenseact Open Dataset

--- a/VisionPilot/modules/safety_guardian/fusion/include/fusion/longitudinal_fusion.hpp
+++ b/VisionPilot/modules/safety_guardian/fusion/include/fusion/longitudinal_fusion.hpp
@@ -47,15 +47,8 @@ public:
         float autodrive_noise_min_m = 1.5f;   // noise floor when AD is fully confident
         float autodrive_noise_m     = 8.f;    // noise ceiling at minimum AD confidence
         float cipo_noise_m          = 3.f;    // CIPO bbox-projected distance noise
-        // AutoSpeed H-matrix distances above this are treated as invalid (slopes /
-        // inclines blow up homography).  When AD confirms CIPO, discarded AS is
-        // ignored for fusion and reinit — AD is used alone.
-        float cipo_h_clamp_m = 150.f;
-        // // When AD confirms CIPO, also discard AS if it disagrees with AD by more
-        // // than this (catches H blow-ups in the 150–200 m band).
-        // float cipo_ad_disagree_m     = 60.f;
-        // // Reinitialise filter when a trusted measurement jumps this far from the
-        // // particle cloud (genuine cut-in / cut-out only).
+        // Reinitialise filter when a measurement jumps this far from the
+        // particle cloud (genuine cut-in / cut-out only).
         float reset_gate_m          = 25.f;
         bool  debug                = false;
     };

--- a/VisionPilot/modules/safety_guardian/fusion/include/fusion/longitudinal_fusion.hpp
+++ b/VisionPilot/modules/safety_guardian/fusion/include/fusion/longitudinal_fusion.hpp
@@ -39,13 +39,24 @@ public:
         float d_max_m              = 150.f;
         float dt_s                 = 0.10f;   // nominal dt; overridden per-call
         // Keep small (MRPT uses 0.03 m). Large values cause particle drift → bad velocity.
-        float process_noise_dist_m = 0.05f;
-        float process_noise_vel_ms = 0.20f;   // matches MRPT TRANSITION_MODEL_STD_VXY
-        float autodrive_noise_m    = 15.f;
-        float cipo_noise_m         = 5.f;
-        // Reinitialise filter when a reliable measurement jumps this far from
-        // the particle cloud — handles genuine cut-in / cut-out events.
-        float reset_gate_m         = 25.f;
+        float process_noise_dist_m  = 2.0f;
+        float process_noise_vel_ms  = 0.50f;
+        // AD noise is scaled by confidence: tight when flag_prob≈1, loose when flag_prob≈threshold.
+        // at p=1.00 → stddev = autodrive_noise_min_m  (AD dominates)
+        // at p=0.40 → stddev = autodrive_noise_m       (CIPO can dominate)
+        float autodrive_noise_min_m = 1.5f;   // noise floor when AD is fully confident
+        float autodrive_noise_m     = 8.f;    // noise ceiling at minimum AD confidence
+        float cipo_noise_m          = 3.f;    // CIPO bbox-projected distance noise
+        // AutoSpeed H-matrix distances above this are treated as invalid (slopes /
+        // inclines blow up homography).  When AD confirms CIPO, discarded AS is
+        // ignored for fusion and reinit — AD is used alone.
+        float cipo_h_clamp_m = 150.f;
+        // // When AD confirms CIPO, also discard AS if it disagrees with AD by more
+        // // than this (catches H blow-ups in the 150–200 m band).
+        // float cipo_ad_disagree_m     = 60.f;
+        // // Reinitialise filter when a trusted measurement jumps this far from the
+        // // particle cloud (genuine cut-in / cut-out only).
+        float reset_gate_m          = 25.f;
         bool  debug                = false;
     };
 

--- a/VisionPilot/modules/safety_guardian/fusion/src/lateral_fusion.cpp
+++ b/VisionPilot/modules/safety_guardian/fusion/src/lateral_fusion.cpp
@@ -30,6 +30,8 @@ void LateralFusion::reset()
 {
     cy_.clear();  cy_init_ = false;
     k_.clear();   k_init_  = false;
+    poly_kf_ = PolyKF{};
+    kf_      = KFState{};
 }
 
 // ─── Public update ────────────────────────────────────────────────────────────
@@ -51,17 +53,57 @@ LateralFusionEstimate LateralFusion::update(
             path = fit_ransac(pts);
     }
 
+    // Record raw RANSAC outputs for debug.
+    est.path_valid         = path.valid;
+    est.raw_cte_m          = path.cte_m;
+    est.raw_yaw_rad        = path.yaw_rad;
+    est.raw_path_curvature = path.curvature;
+    est.path_inliers       = path.inliers;
+    est.path_x_min_m       = path.x_min_m;
+    est.path_x_max_m       = path.x_max_m;
 
-        est.path_valid         = path.valid;
-        est.raw_cte_m          = path.cte_m;
-        est.raw_yaw_rad        = path.yaw_rad;
-        est.raw_path_curvature = path.curvature;
-        est.path_inliers       = path.inliers;
-        est.path_a             = path.a;
-        est.path_b             = path.b;
-        est.path_c             = path.c;
-        est.path_x_min_m       = path.x_min_m;
-        est.path_x_max_m       = path.x_max_m;
+    // ── Step 2b: Polynomial-coefficient Kalman smoother ─────────────────────
+    //  Always predict (P grows when path is missing so KF re-acquires quickly).
+    //  Update only when RANSAC succeeded.  The smoothed (sa, sb, sc) coefficients
+    //  are used downstream for BOTH the PF measurements AND the visualization.
+    //  This is the primary fix for sudden path jumps at lane merges.
+    if (poly_kf_.init)
+        poly_kf_predict(dt);
+
+    if (path.valid) {
+        const float quality = static_cast<float>(path.inliers) /
+                              std::max(1.f, static_cast<float>(cfg_.ransac_min_inliers));
+        if (!poly_kf_.init) {
+            poly_kf_.x[0] = path.a;
+            poly_kf_.x[1] = path.b;
+            poly_kf_.x[2] = path.c;
+            poly_kf_.P[0] = cfg_.poly_meas_R_a;
+            poly_kf_.P[1] = cfg_.poly_meas_R_b;
+            poly_kf_.P[2] = cfg_.poly_meas_R_c;
+            poly_kf_.init = true;
+        } else {
+            poly_kf_update(path.a, path.b, path.c, quality);
+        }
+    }
+
+    // Use smoothed polynomial for everything downstream; fall back to raw if KF
+    // not yet initialised (very first frame or after a long gap).
+    const float sa = poly_kf_.init ? poly_kf_.x[0] : path.a;
+    const float sb = poly_kf_.init ? poly_kf_.x[1] : path.b;
+    const float sc = poly_kf_.init ? poly_kf_.x[2] : path.c;
+
+    // Derive smoothed CTE, yaw, curvature from the smoothed polynomial.
+    const float x_ref         = path.x_min_m;
+    const float smooth_cte    = eval_quad(sa, sb, sc, x_ref);
+    const float dydx_smooth   = 2.f * sa * x_ref + sb;
+    const float smooth_yaw    = std::atan(dydx_smooth);
+    const float denom         = std::pow(1.f + dydx_smooth * dydx_smooth, 1.5f);
+    const float smooth_curv   = (denom > 1e-6f) ? (2.f * sa / denom) : 0.f;
+
+    // Set visualization path to the smoothed polynomial coefficients.
+    est.path_a = sa;
+    est.path_b = sb;
+    est.path_c = sc;
 
     // ── Step 3: AutoDrive curvature ───────────────────────────────────────────
     float ad_curv = 0.f;
@@ -73,29 +115,30 @@ LateralFusionEstimate LateralFusion::update(
     }
 
     // ── Step 4: CTE / Yaw particle filter ────────────────────────────────────
-    if (path.valid) {
+    //  Feed the PF the SMOOTHED CTE/yaw so it doesn't jump at merges.
+    if (poly_kf_.init && (path.valid || cy_init_)) {
         // Apply camera mounting offset correction before feeding the filter.
-        const float corrected_cte = path.cte_m - cfg_.cte_bias_m;
+        const float corrected_cte = smooth_cte - cfg_.cte_bias_m;
         if (!cy_init_) {
-            cy_init(corrected_cte, path.yaw_rad);
-        } else {
+            cy_init(corrected_cte, smooth_yaw);
+        } else if (path.valid) {
             cy_predict(dt);
             cy_update(corrected_cte, cfg_.meas_noise_cte_m,
-                      path.yaw_rad, cfg_.meas_noise_yaw_rad);
+                      smooth_yaw, cfg_.meas_noise_yaw_rad);
             if (cy_eff_n() < 0.5f * static_cast<float>(cfg_.n_particles))
                 cy_resample();
         }
     }
 
     // ── Step 5: Curvature particle filter ────────────────────────────────────
-    // Initialise from whichever source is available first.
+    // Feed the PF the SMOOTHED curvature from the polynomial KF.
     if (!k_init_) {
-        if      (path.valid)    k_init(path.curvature);
+        if      (poly_kf_.init) k_init(smooth_curv);
         else if (ad_curv_valid) k_init(ad_curv);
     } else {
         k_predict(dt);
-        if (path.valid)    k_update(path.curvature, cfg_.meas_noise_curv_path);
-        if (ad_curv_valid) k_update(ad_curv,        cfg_.meas_noise_curv_ad);
+        if (poly_kf_.init && path.valid) k_update(smooth_curv, cfg_.meas_noise_curv_path);
+        if (ad_curv_valid)               k_update(ad_curv,     cfg_.meas_noise_curv_ad);
         if (k_eff_n() < 0.5f * static_cast<float>(cfg_.n_particles))
             k_resample();
     }
@@ -137,26 +180,68 @@ LateralFusionEstimate LateralFusion::update(
         est.valid       = true;
     }
 
-    // ── Step 7: Debug log ─────────────────────────────────────────────────────
+    // ── Step 7: Rao-Blackwellized Kalman smoother on PF posterior ─────────────
+    //  Always predict (grows P when no measurement arrives).
+    //  Update only when RANSAC path is valid — that is when we have a fresh,
+    //  geometrically consistent measurement.  During missing-path frames the KF
+    //  just predicts forward, preventing the PF's raw estimate from snapping.
+    if (kf_.init)
+        kf_predict(dt);
+
+    if (est.valid) {
+        if (!kf_.init) {
+            kf_.x[0] = est.cte_m;
+            kf_.x[1] = est.yaw_rad;
+            kf_.x[2] = est.curvature;
+            // Bootstrap P from PF posterior variance (generous lower bound)
+            kf_.P[0] = std::max(est.cte_stddev_m   * est.cte_stddev_m,   0.25f);
+            kf_.P[1] = std::max(est.yaw_stddev_rad * est.yaw_stddev_rad,  0.01f);
+            kf_.P[2] = std::max(est.curv_stddev    * est.curv_stddev,     cfg_.kf_meas_R_curv_min);
+            kf_.init = true;
+        } else if (path.valid) {
+            // Measurement = PF posterior mean; noise = PF posterior variance.
+            // High PF variance  → low KF gain → KF barely reacts (e.g. mid-merge).
+            // Low  PF variance  → high KF gain → KF follows quickly (converged lane).
+            const float z[3] = {est.cte_m, est.yaw_rad, est.curvature};
+            const float R[3] = {
+                std::max(est.cte_stddev_m   * est.cte_stddev_m,   1e-4f),
+                std::max(est.yaw_stddev_rad * est.yaw_stddev_rad,  1e-6f),
+                std::max(est.curv_stddev    * est.curv_stddev,     cfg_.kf_meas_R_curv_min),
+            };
+            kf_update(z, R);
+        }
+        // Replace PF posterior with KF-smoothed output
+        est.cte_m     = kf_.x[0];
+        est.yaw_rad   = kf_.x[1];
+        est.curvature = kf_.x[2];
+    }
+
+    // ── Step 8: Debug log ─────────────────────────────────────────────────────
     if (cfg_.debug) {
-        char path_buf[96], ad_buf[32];
+        char path_buf[128], poly_buf[96], ad_buf[32];
         if (path.valid)
             std::snprintf(path_buf, sizeof(path_buf),
-                          "raw_CTE=%.2fm  bias=%.2fm  corr=%.2fm  yaw=%.3frad  κ=%.4f  (%d pts, xmin=%.1fm)",
-                          path.cte_m, cfg_.cte_bias_m, path.cte_m - cfg_.cte_bias_m,
-                          path.yaw_rad, path.curvature, path.inliers, path.x_min_m);
+                          "raw(CTE=%.2fm yaw=%.3frad κ=%.4f, %d pts)",
+                          path.cte_m, path.yaw_rad, path.curvature, path.inliers);
         else
-            std::snprintf(path_buf, sizeof(path_buf), "(no path fit, %d pts)", est.path_points);
+            std::snprintf(path_buf, sizeof(path_buf), "(no path, %d pts)", est.path_points);
+
+        if (poly_kf_.init)
+            std::snprintf(poly_buf, sizeof(poly_buf),
+                          "poly-KF(CTE=%.2fm yaw=%.3frad κ=%.4f P_c=%.4f)",
+                          smooth_cte, smooth_yaw, smooth_curv, poly_kf_.P[2]);
+        else
+            std::snprintf(poly_buf, sizeof(poly_buf), "poly-KF(uninit)");
 
         if (ad_curv_valid)
-            std::snprintf(ad_buf, sizeof(ad_buf), "%.4f (raw=%.4f)",
-                          ad_curv, drive.curvature_raw);
+            std::snprintf(ad_buf, sizeof(ad_buf), "%.4f", ad_curv);
         else
             std::snprintf(ad_buf, sizeof(ad_buf), "(none)");
 
-        VP_INFO("[Lateral] Path: %s | AD-κ=%s | Fused CTE=%.2fm yaw=%.3frad κ=%.4f",
-                path_buf, ad_buf,
-                est.cte_m, est.yaw_rad, est.curvature);
+        VP_INFO("[Lateral] %s | %s | AD-κ=%s | out CTE=%.2fm yaw=%.3frad κ=%.4f  KF-P=[%.3f %.4f %.6f]",
+                path_buf, poly_buf, ad_buf,
+                est.cte_m, est.yaw_rad, est.curvature,
+                kf_.P[0], kf_.P[1], kf_.P[2]);
     }
 
     return est;
@@ -410,6 +495,69 @@ float LateralFusion::k_eff_n() const
 }
 
 void LateralFusion::k_resample() { systematic_resample(k_); }
+
+// ─── Rao-Blackwellized Kalman smoother ────────────────────────────────────────
+// ─── Polynomial-coefficient Kalman smoother ────────────────────────────────────
+//  Smooths raw RANSAC (a, b, c) before they drive the PF and visualization.
+//  Prevents sudden path-corridor jumps during lane merges.
+//  Random-walk process: F = I,  Q = diag(proc²·dt),  H = I.
+//
+void LateralFusion::poly_kf_predict(float dt)
+{
+    const float q[3] = {
+        cfg_.poly_proc_a_s * cfg_.poly_proc_a_s * dt,
+        cfg_.poly_proc_b_s * cfg_.poly_proc_b_s * dt,
+        cfg_.poly_proc_c_s * cfg_.poly_proc_c_s * dt,
+    };
+    for (int i = 0; i < 3; ++i)
+        poly_kf_.P[i] += q[i];
+}
+
+// quality = actual_inliers / ransac_min_inliers ≥ 1.
+// More inliers → smaller effective R → KF follows the fit faster.
+void LateralFusion::poly_kf_update(float a, float b, float c, float quality)
+{
+    // Scale base measurement noise inversely with inlier quality.
+    // quality ≥ 1 always, so R only decreases (fit is more reliable).
+    const float iq = 1.f / std::max(quality, 1.f);
+    const float R[3] = {
+        cfg_.poly_meas_R_a * iq,
+        cfg_.poly_meas_R_b * iq,
+        cfg_.poly_meas_R_c * iq,
+    };
+    const float z[3] = {a, b, c};
+    for (int i = 0; i < 3; ++i) {
+        const float K    = poly_kf_.P[i] / (poly_kf_.P[i] + R[i] + 1e-12f);
+        poly_kf_.x[i]  += K * (z[i] - poly_kf_.x[i]);
+        poly_kf_.P[i]  *= (1.f - K);
+    }
+}
+
+// ─── Rao-Blackwellized Kalman smoother (post-PF scalar smoother) ───────────────
+//  Random-walk process: x_{k|k-1} = x_{k-1},  P_{k|k-1} = P_{k-1} + Q
+//  Measurement:         H = I  →  K = P / (P + R),  simple scalar update per state.
+//
+void LateralFusion::kf_predict(float dt)
+{
+    // Q_i = (proc_noise_i_per_s)² · dt  — grow uncertainty proportional to elapsed time
+    const float q[3] = {
+        cfg_.kf_proc_cte_m_s   * cfg_.kf_proc_cte_m_s   * dt,
+        cfg_.kf_proc_yaw_rad_s * cfg_.kf_proc_yaw_rad_s * dt,
+        cfg_.kf_proc_curv_s    * cfg_.kf_proc_curv_s    * dt,
+    };
+    for (int i = 0; i < 3; ++i)
+        kf_.P[i] += q[i];
+    // x_{k|k-1} = x_{k-1}  (identity transition)
+}
+
+void LateralFusion::kf_update(const float z[3], const float R[3])
+{
+    for (int i = 0; i < 3; ++i) {
+        const float K    = kf_.P[i] / (kf_.P[i] + R[i] + 1e-9f);
+        kf_.x[i]        += K * (z[i] - kf_.x[i]);
+        kf_.P[i]        *= (1.f - K);
+    }
+}
 
 // ─── Shared helpers ────────────────────────────────────────────────────────────
 

--- a/VisionPilot/modules/safety_guardian/fusion/src/longitudinal_fusion.cpp
+++ b/VisionPilot/modules/safety_guardian/fusion/src/longitudinal_fusion.cpp
@@ -76,7 +76,9 @@ CIPOFusionEstimate LongitudinalFusion::update(
     Meas ad_meas;
     if (ad_cipo_confirmed) {
         ad_meas.distance_m = D_MAX * (1.f - autodrive.dist_normalized);
-        ad_meas.stddev_m   = cfg_.autodrive_noise_m;
+        const float p      = std::clamp(autodrive.flag_prob, 0.f, 1.f);
+        ad_meas.stddev_m   = cfg_.autodrive_noise_min_m +
+                             (cfg_.autodrive_noise_m - cfg_.autodrive_noise_min_m) * (1.f - p);
         ad_meas.valid      = true;
     }
 
@@ -84,42 +86,33 @@ CIPOFusionEstimate LongitudinalFusion::update(
     const float dt = (dt_s > 1e-6f) ? dt_s : cfg_.dt_s;
 
     if (!initialised_) {
-        // Prefer AD for first init; fall back to CIPO raw if AD isn't available.
         if (ad_meas.valid) {
             init_from(ad_meas.distance_m, ad_meas.stddev_m);
         } else if (cipo_raw.valid) {
             init_from(cipo_raw.distance_m, cfg_.cipo_noise_m);
         } else {
-            return est;   // nothing to init from — return default (distance_m=0 won't happen because we returned D_MAX above)
+            return est;
         }
         initialised_ = true;
     } else {
         predict(dt);
 
-        // ── Innovation gate ───────────────────────────────────────────────────
-        // If the CIPO target changes (cut-in or cut-out), the projected distance
-        // jumps in one direction or the other.  A single absolute-distance check
-        // on CIPO raw covers both:
-        //   cut-out → cipo_raw >> cloud  (farther car now tracked)
-        //   cut-in  → cipo_raw << cloud  (closer car appeared)
-        // Fall back to AD when CIPO raw has no detection (car fully left frame).
-        {
-            float cloud_mean = 0.f;
-            for (const auto& p : particles_) cloud_mean += p.distance_m;
-            cloud_mean /= static_cast<float>(particles_.size());
+        float cloud_mean = 0.f;
+        for (const auto& p : particles_) cloud_mean += p.distance_m;
+        cloud_mean /= static_cast<float>(particles_.size());
 
-            if (cipo_raw.valid &&
-                std::abs(cipo_raw.distance_m - cloud_mean) > cfg_.reset_gate_m) {
-                VP_INFO("[Fusion] Target change — reinit %.1f→%.1f m (CIPO)",
-                        cloud_mean, cipo_raw.distance_m);
-                init_from(cipo_raw.distance_m, cfg_.cipo_noise_m);
-            } else if (ad_meas.valid &&
-                       (ad_meas.distance_m - cloud_mean) > cfg_.reset_gate_m) {
-                // CIPO not detected but AD jumped up — car left the lane entirely
-                VP_INFO("[Fusion] Cut-out (no CIPO) — reinit %.1f→%.1f m (AD)",
-                        cloud_mean, ad_meas.distance_m);
-                init_from(ad_meas.distance_m, ad_meas.stddev_m);
-            }
+        const float gate = cfg_.reset_gate_m;
+
+        if (cipo_raw.valid &&
+            std::abs(cipo_raw.distance_m - cloud_mean) > gate) {
+            VP_INFO("[Fusion] Target change — reinit %.1f→%.1f m (CIPO)  gate=%.1f",
+                    cloud_mean, cipo_raw.distance_m, gate);
+            init_from(cipo_raw.distance_m, cfg_.cipo_noise_m);
+        } else if (ad_meas.valid &&
+                   (ad_meas.distance_m - cloud_mean) > gate) {
+            VP_INFO("[Fusion] Cut-out — reinit %.1f→%.1f m (AD)  gate=%.1f",
+                    cloud_mean, ad_meas.distance_m, gate);
+            init_from(ad_meas.distance_m, ad_meas.stddev_m);
         }
     }
 
@@ -151,9 +144,10 @@ CIPOFusionEstimate LongitudinalFusion::update(
     if (cfg_.debug) {
         char ad_buf[48], cr_buf[32];
         if (ad_meas.valid)
-            std::snprintf(ad_buf, sizeof(ad_buf), "%.1f m (p=%.0f%%)",
+            std::snprintf(ad_buf, sizeof(ad_buf), "%.1f m (p=%.0f%% σ=%.1fm)",
                           ad_meas.distance_m,
-                          autodrive.valid ? autodrive.flag_prob * 100.f : 0.f);
+                          autodrive.valid ? autodrive.flag_prob * 100.f : 0.f,
+                          ad_meas.stddev_m);
         else
             std::snprintf(ad_buf, sizeof(ad_buf), "(p=%.0f%% < %.0f%%)",
                           autodrive.valid ? autodrive.flag_prob * 100.f : 0.f,
@@ -194,10 +188,12 @@ LongitudinalFusion::select_cipo(const std::vector<models::Detection>& dets) cons
 
     for (const auto& d : dets) {
         if (d.class_id != 1 && d.class_id != 2) continue;
-        const float dist = project_dist(H_,
-                                        (d.x1 + d.x2) * 0.5f,
-                                        d.y2);
-        if (dist <= 0.f) continue;
+        const float cx   = (d.x1 + d.x2) * 0.5f;
+        const float dist = project_dist(H_, cx, d.y2);
+        if (cfg_.debug) {
+            VP_INFO("[CIPO-DBG] cls=%d  bbox=(%.0f,%.0f,%.0f,%.0f)  bottom-center=(%.0f,%.0f) → %.1f m",
+                    d.class_id, d.x1, d.y1, d.x2, d.y2, cx, d.y2, dist);
+        }
         if (d.class_id == 1 && dist < best_l1) best_l1 = dist;
         if (d.class_id == 2 && dist < best_l2) best_l2 = dist;
     }

--- a/VisionPilot/modules/sensing/image_preprocessing/src/image_preprocessor.cpp
+++ b/VisionPilot/modules/sensing/image_preprocessing/src/image_preprocessor.cpp
@@ -13,8 +13,10 @@ void ImagePreprocessor::preprocess(const cv::Mat& image, cv::Mat& warped_image, 
     cv::warpPerspective(image, warped_image, C_, cv::Size(1024, 512), cv::INTER_LINEAR,
                         cv::BORDER_REFLECT_101);
 
-    int crop_h = (image.rows - image.cols / 2) / 2;
-    cv::Rect roi(0, crop_h, image.cols, image.rows - 2 * crop_h);
-    cv::Mat cropped_image = image(roi);
-    cv::resize(cropped_image, resized_image, size);
+    // AutoSteer / AutoSpeed: top-crop to 2:1 → resize 1024×512
+    // (matches Python --preprocess top-crop-2-1 / auto_steer_infer.py).
+    const int crop_top = compute_top_crop_2_1(image.rows, image.cols);
+    const cv::Rect roi(0, crop_top, image.cols, image.rows - crop_top);
+    cv::Mat cropped = image(roi);
+    cv::resize(cropped, resized_image, size, 0, 0, cv::INTER_LINEAR);
 }

--- a/VisionPilot/modules/visualization/src/visualization.cpp
+++ b/VisionPilot/modules/visualization/src/visualization.cpp
@@ -242,7 +242,7 @@ static void draw_cipo_boxes(cv::Mat& img, const ProductionView& view) {
     }
 
     // ── Distance label on the closest L1 (most centred) ──────────────────────
-    if (view.cipo.valid && view.cipo.distance_m < kDMax) {
+    if (view.cipo.valid && view.cipo.distance_m > 0.f) {
         const ProductionView::BBox* best = nullptr;
         float best_cx_err = 1e9f;
         for (const auto& d : view.detections) {

--- a/VisionPilot/modules/visualization/src/visualization.cpp
+++ b/VisionPilot/modules/visualization/src/visualization.cpp
@@ -213,6 +213,21 @@ static void draw_path_corridor(cv::Mat& img, const ProductionView& view) {
     cv::addWeighted(overlay, 0.35, img, 0.65, 0.0, img);
 }
 
+// AutoSpeed bbox colors — match debug_draw.cpp det_color()
+static cv::Scalar autospeed_det_color(int class_id) {
+    switch (class_id) {
+        case 1: return cv::Scalar(0, 0, 220);     // L1 red
+        case 2: return cv::Scalar(0, 210, 255);   // L2 yellow
+        case 3: return cv::Scalar(220, 200, 0);   // L3 blue
+        default: return cv::Scalar(80, 200, 80);  // other green
+    }
+}
+
+static cv::Scalar autospeed_det_fill(int class_id) {
+    const cv::Scalar c = autospeed_det_color(class_id);
+    return cv::Scalar(c[0] * 0.35, c[1] * 0.35, c[2] * 0.35);
+}
+
 // ─── Draw: AutoSpeed bounding boxes + CIPO distance label ─────────────────────
 static void draw_cipo_boxes(cv::Mat& img, const ProductionView& view) {
     if (view.detections.empty()) return;
@@ -220,25 +235,19 @@ static void draw_cipo_boxes(cv::Mat& img, const ProductionView& view) {
     // Semi-transparent fill pass
     cv::Mat overlay = img.clone();
     for (const auto& d : view.detections) {
-        const cv::Scalar fill = (d.class_id == 1)
-            ? cv::Scalar(30, 30, 200)    // red  — same-lane (Level 1)
-            : cv::Scalar(200, 80,  30);  // blue — adjacent  (Level 2)
         cv::rectangle(overlay,
             cv::Point(static_cast<int>(d.x1), static_cast<int>(d.y1)),
             cv::Point(static_cast<int>(d.x2), static_cast<int>(d.y2)),
-            fill, -1);
+            autospeed_det_fill(d.class_id), -1);
     }
     cv::addWeighted(overlay, 0.32, img, 0.68, 0.0, img);
 
     // Outline pass (hard edges on top)
     for (const auto& d : view.detections) {
-        const cv::Scalar outline = (d.class_id == 1)
-            ? cv::Scalar(0,   0,   240)
-            : cv::Scalar(240, 110,  30);
         cv::rectangle(img,
             cv::Point(static_cast<int>(d.x1), static_cast<int>(d.y1)),
             cv::Point(static_cast<int>(d.x2), static_cast<int>(d.y2)),
-            outline, 2, cv::LINE_AA);
+            autospeed_det_color(d.class_id), 2, cv::LINE_AA);
     }
 
     // ── Distance label on the closest L1 (most centred) ──────────────────────
@@ -438,7 +447,7 @@ static void draw_speed_limit(cv::Mat& img, double speed_limit_ms) {
 }
 
 // ─── Draw: AutoDrive-only in-path CIPO arrow (AD detects, AutoSpeed misses) ──
-// Projects AD distance onto image using world→px H, draws a red downward arrow.
+// Projects AD distance onto the fused path centerline; Comma-style filled triangle.
 static void draw_ad_only_cipo(cv::Mat& img, const ProductionView& view) {
     if (!view.ad_cipo_only) return;
     if (view.ad_distance_m <= 0.f || view.ad_distance_m >= kDMax) return;
@@ -446,8 +455,13 @@ static void draw_ad_only_cipo(cv::Mat& img, const ProductionView& view) {
     const cv::Mat& H_w2px = (!view.H_world2px.empty()) ? view.H_world2px : g_H_world2px;
     if (H_w2px.empty()) return;
 
-    // Project world point (ad_distance_m ahead, 0 lateral) → image pixel
-    std::vector<cv::Point2f> src = {cv::Point2f(view.ad_distance_m, 0.f)}, dst;
+    // Place on path center at AD distance (not fixed lateral y=0).
+    const float xw = view.ad_distance_m;
+    float yw = 0.f;
+    if (view.path_valid)
+        yw = view.path_a * xw * xw + view.path_b * xw + view.path_c;
+
+    std::vector<cv::Point2f> src = {cv::Point2f(xw, yw)}, dst;
     cv::perspectiveTransform(src, dst, H_w2px);
 
     const int px = static_cast<int>(std::lround(dst[0].x));
@@ -455,31 +469,32 @@ static void draw_ad_only_cipo(cv::Mat& img, const ProductionView& view) {
 
     if (px < 0 || px >= img.cols || py < 0 || py >= img.rows) return;
 
-    // Red downward triangle arrow
-    const int aw = 28, ah = 36;
-    const std::vector<cv::Point> tri = {
-        cv::Point(px,      py + ah),   // tip (bottom)
-        cv::Point(px - aw, py),         // top-left
-        cv::Point(px + aw, py),         // top-right
-    };
-    cv::fillConvexPoly(img, tri, cv::Scalar(0, 0, 230), cv::LINE_AA);
-    cv::polylines(img, tri, true, cv::Scalar(0, 0, 255), 2, cv::LINE_AA);
+    // Comma-style: filled orange triangle, tip toward horizon (30% smaller than original).
+    static constexpr int kAw = 20;
+    static constexpr int kAh = 25;
+    static const cv::Scalar kOrange(80, 180, 255);  // BGR — soft orange
 
-    // Distance label above the arrow
+    const std::vector<cv::Point> tri = {
+        cv::Point(px,      py - kAh),   // tip — ahead on path
+        cv::Point(px - kAw, py),         // base-left
+        cv::Point(px + kAw, py),         // base-right
+    };
+    cv::fillConvexPoly(img, tri, kOrange, cv::LINE_AA);
+    cv::polylines(img, tri, true, kOrange, 1, cv::LINE_AA);
+
     char lbl[16];
     std::snprintf(lbl, sizeof(lbl), "%.0fm", static_cast<double>(view.ad_distance_m));
     int bl = 0;
     cv::Size ts = cv::getTextSize(lbl, cv::FONT_HERSHEY_SIMPLEX, 0.52, 2, &bl);
     const int tx = px - ts.width / 2;
-    const int ty = py - 8;
+    const int ty = py - kAh - 8;
     if (ty > ts.height) {
         cv::rectangle(img,
             cv::Point(tx - 4, ty - ts.height - 2),
             cv::Point(tx + ts.width + 4, ty + 4),
             cv::Scalar(20, 20, 20), -1);
         cv::putText(img, lbl, cv::Point(tx, ty),
-                    cv::FONT_HERSHEY_SIMPLEX, 0.52,
-                    cv::Scalar(0, 0, 230), 2, cv::LINE_AA);
+                    cv::FONT_HERSHEY_SIMPLEX, 0.52, kOrange, 2, cv::LINE_AA);
     }
 }
 


### PR DESCRIPTION
 **Final Version for release**

Please build and test in your local  env. 

**Key changes** 

Preprocessor - now usess top crop calculated based on height and width to skip top sky part,

inference -  T matrix and H_resized are now calculated based on top crop preprocessing

Lateral fusion - KF filter to smooth out abc, params for RANSAC  fit for curve.

Longitudinal fusion - Almost same. No major changes to Particle filter

Visualization - Fixed AutoSpeed color schema, with semi filled version and Comma AI style arrow on the path.  
