### PR TITLE
fix(dependency): use libopencv-dev rosdep key for OpenCV dependency

### DIFF
--- a/VisionPilot/package.xml
+++ b/VisionPilot/package.xml
@@ -17,7 +17,7 @@
   <depend>geometry_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
-  <depend>opencv</depend>
+  <depend>libopencv-dev</depend>
 
   <!-- Testing dependencies -->
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
Fixes #370

## Problem
Registering `vision_pilot` in the [Autoware Index](https://autowarefoundation.github.io/autoware-index/) fails its rosdep CI check:

```
ERROR: the following packages/stacks could not have their rosdep keys resolved to system dependencies:
vision_pilot: Cannot locate rosdep definition for [opencv]
```

`VisionPilot/package.xml` declares `<depend>opencv</depend>`, but `opencv` is not a valid rosdep key — there is no such definition in rosdistro.

## Fix
Use the canonical `libopencv-dev` rosdep key, which resolves to the OpenCV apt package that provides the CMake config consumed by the packages `find_package(OpenCV REQUIRED)` calls. One-line change to `VisionPilot/package.xml`.