### PR TITLE
fix: make the ROS 2 interface work out of the box (build, topics, camera encoding)

### DIFF
--- a/VisionPilot/app/vision_pilot.cpp
+++ b/VisionPilot/app/vision_pilot.cpp
@@ -22,6 +22,7 @@
 
 #if ENABLE_ROS2_INTERFACE
 #include <rclcpp/rclcpp.hpp>
+#include <camera_subscriber/ros2_to_opencv.hpp>
 #include <vehicle_ros2_interface/vehicle_ros2_interface.hpp>
 #endif
 
@@ -52,7 +53,8 @@ int main(int argc, char** argv)
     std::shared_ptr<VehicleInterface> vehicle_interface;
 #ifdef ENABLE_ROS2_INTERFACE
     rclcpp::init(argc, argv);
-    camera_interface = std::make_unique<ROS2ImageSubscriber>(cfg.input_camera_topic);
+    camera_interface = std::make_unique<camera_interface::ROS2ImageSubscriber>(
+        cfg.source.input_camera_topic);
     vehicle_interface = std::make_shared<VehicleRos2Interface>(cfg.vehicle_speed_topic,
                                                                cfg.vehicle_steering_topic,
                                                                cfg.vehicle_acceleration_topic);

--- a/VisionPilot/modules/config/src/vision_pilot_config.cpp
+++ b/VisionPilot/modules/config/src/vision_pilot_config.cpp
@@ -151,7 +151,7 @@ Config load_vision_pilot_config()
     cfg.source.input_camera_topic = optional(kv, "source.input_camera_topic",  "/camera/image");
     cfg.vehicle_speed_topic = optional(kv, "vehicle_speed_topic", "/vehicle/speed");
     cfg.vehicle_steering_topic = optional(kv, "vehicle_steering_topic", "/vehicle/steering_cmd");
-    cfg.vehicle_acceleration_topic = optional(kv, "vehicle_acceleration_topic", "/vehicle/steering_cmd");
+    cfg.vehicle_acceleration_topic = optional(kv, "vehicle_acceleration_topic", "/vehicle/throttle_cmd");
 #endif
 
     // Load test configuration

--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_subscriber/include/camera_subscriber/ros2_to_opencv.hpp
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_subscriber/include/camera_subscriber/ros2_to_opencv.hpp
@@ -3,7 +3,12 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
+// ROS 2 Jazzy+ ships only cv_bridge/cv_bridge.hpp; Humble ships only cv_bridge/cv_bridge.h.
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <opencv2/opencv.hpp>
 #include <cstdint>
 #include <memory>

--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_subscriber/src/ros2_to_opencv.cpp
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_subscriber/src/ros2_to_opencv.cpp
@@ -1,7 +1,10 @@
 #include <camera_subscriber/ros2_to_opencv.hpp>
 
+#include <sensor_msgs/image_encodings.hpp>
+
 #include <algorithm>
 #include <memory>
+#include <string>
 #include <thread>
 
 namespace camera_interface {
@@ -115,7 +118,13 @@ namespace camera_interface {
             // For desired output encoding:
             //      - "bgr8"  : commonly used for color images
             //      - "mono8" : for grayscale
-            cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, msg->encoding);
+            // The pipeline consumes 3-channel BGR (CV_8UC3), so normalize any color
+            // encoding (e.g. bgra8, rgb8) to bgr8; mono frames pass through unchanged.
+            const std::string& encoding = msg->encoding;
+            const bool is_mono = encoding == sensor_msgs::image_encodings::MONO8 ||
+                                 encoding == sensor_msgs::image_encodings::MONO16;
+            cv_bridge::CvImagePtr cv_ptr =
+                cv_bridge::toCvCopy(msg, is_mono ? encoding : sensor_msgs::image_encodings::BGR8);
             return cv_ptr->image;
 
         } catch (cv_bridge::Exception &e) {

--- a/VisionPilot/modules/sensing/camera_interface/CMakeLists.txt
+++ b/VisionPilot/modules/sensing/camera_interface/CMakeLists.txt
@@ -32,6 +32,9 @@ target_link_libraries(camera_interface
 )
 
 if(ENABLE_ROS2_INTERFACE)
+    # camera_subscriber propagates rclcpp's imported targets (e.g. fastcdr on
+    # ROS 2 Humble); imported targets are directory-scoped, so find them here too.
+    find_package(rclcpp REQUIRED)
     target_compile_definitions(camera_interface PRIVATE ENABLE_ROS2_INTERFACE)
     target_link_libraries(camera_interface PRIVATE camera_subscriber)
 endif()

--- a/VisionPilot/modules/visualization/src/visualization.cpp
+++ b/VisionPilot/modules/visualization/src/visualization.cpp
@@ -312,7 +312,7 @@ static void draw_speed(cv::Mat& img, double speed_ms) {
     cv::putText(overlay, unit_buf, cv::Point(unit_tx, unit_ty),
                 cv::FONT_HERSHEY_DUPLEX, 0.5, cv::Scalar(255, 255, 255), 1, cv::LINE_AA);
 
-    cv::addWeighted(overlay, 1.0, img, 0.5, 0, img);
+    cv::addWeighted(overlay, 0.85, img, 0.15, 0.0, img);
 }
 
 // ─── Helper: production HUD text (Duplex + subtle shadow) ────────────────────

--- a/VisionPilot/tests/CMakeLists.txt
+++ b/VisionPilot/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.22.1)
 
 add_subdirectory(app)
+add_subdirectory(config)
 add_subdirectory(sensing/image_preprocessing)
 add_subdirectory(safety_guardian/planning)

--- a/VisionPilot/tests/CMakeLists.txt
+++ b/VisionPilot/tests/CMakeLists.txt
@@ -4,3 +4,7 @@ add_subdirectory(app)
 add_subdirectory(config)
 add_subdirectory(sensing/image_preprocessing)
 add_subdirectory(safety_guardian/planning)
+
+if (ENABLE_ROS2_INTERFACE)
+    add_subdirectory(middleware_interfaces/ros2_interface/camera_subscriber)
+endif ()

--- a/VisionPilot/tests/app/test_vision_pilot.cpp
+++ b/VisionPilot/tests/app/test_vision_pilot.cpp
@@ -23,6 +23,7 @@
 
 #if ENABLE_ROS2_INTERFACE
 #include <rclcpp/rclcpp.hpp>
+#include <camera_subscriber/ros2_to_opencv.hpp>
 #include <vehicle_ros2_interface/vehicle_ros2_interface.hpp>
 #endif
 
@@ -88,7 +89,8 @@ int main(int argc, char** argv)
     std::shared_ptr<VehicleInterface> vehicle_interface;
 #ifdef ENABLE_ROS2_INTERFACE
     rclcpp::init(argc, argv);
-    camera_interface = std::make_unique<ROS2ImageSubscriber>(cfg.input_camera_topic);
+    camera_interface = std::make_unique<camera_interface::ROS2ImageSubscriber>(
+        cfg.source.input_camera_topic);
     vehicle_interface = std::make_shared<VehicleRos2Interface>(cfg.vehicle_speed_topic,
                                                                cfg.vehicle_steering_topic,
                                                                cfg.vehicle_acceleration_topic);

--- a/VisionPilot/tests/config/CMakeLists.txt
+++ b/VisionPilot/tests/config/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(test_config
+        test_config.cpp
+)
+
+target_link_libraries(test_config
+        PRIVATE
+        config
+)

--- a/VisionPilot/tests/config/test_config.cpp
+++ b/VisionPilot/tests/config/test_config.cpp
@@ -1,0 +1,63 @@
+// Guards the config defaults: vehicle_acceleration_topic once defaulted to
+// /vehicle/steering_cmd, interleaving steering and throttle on one topic.
+#include <config/vision_pilot_config.hpp>
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+int g_failures = 0;
+
+void check(const char* name, bool ok)
+{
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+void write_file(const fs::path& p, const std::string& body)
+{
+    std::ofstream f(p);
+    f << body;
+}
+
+}  // namespace
+
+int main()
+{
+    // Stage a minimal conf tree and chdir to it: find_config() reads config/<file>
+    // relative to the CWD. vision_pilot_ros2.conf is left empty so every ROS2
+    // key falls back to its compiled-in default.
+    const fs::path root = fs::temp_directory_path() / "vp_test_config";
+    fs::remove_all(root);
+    fs::create_directories(root / "config");
+    write_file(root / "config" / "vision_pilot.conf",
+               "source.mode = ros2\n"
+               "speed_limit = 10.0\n"
+               "Lf = 2.67\n");
+    write_file(root / "config" / "vision_pilot_ros2.conf", "");
+    fs::current_path(root);
+
+    const Config cfg = load_vision_pilot_config();
+
+    check("source.mode parsed as ros2", cfg.source.mode == SourceMode::Ros2);
+    check("speed_limit parsed", cfg.speed_limit == 10.0);
+
+#ifdef ENABLE_ROS2_INTERFACE
+    check("camera topic default", cfg.source.input_camera_topic == "/camera/image");
+    check("speed topic default", cfg.vehicle_speed_topic == "/vehicle/speed");
+    check("steering topic default", cfg.vehicle_steering_topic == "/vehicle/steering_cmd");
+    check("acceleration topic default", cfg.vehicle_acceleration_topic == "/vehicle/throttle_cmd");
+    check("steering and acceleration topics differ",
+          cfg.vehicle_steering_topic != cfg.vehicle_acceleration_topic);
+#endif
+
+    std::printf("\n%s (%d failure%s)\n", g_failures ? "FAILED" : "ALL PASS", g_failures,
+                g_failures == 1 ? "" : "s");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/VisionPilot/tests/middleware_interfaces/ros2_interface/camera_subscriber/CMakeLists.txt
+++ b/VisionPilot/tests/middleware_interfaces/ros2_interface/camera_subscriber/CMakeLists.txt
@@ -1,0 +1,15 @@
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(OpenCV REQUIRED)
+
+add_executable(test_camera_subscriber
+        test_camera_subscriber.cpp
+)
+
+target_link_libraries(test_camera_subscriber
+        PRIVATE
+        camera_subscriber
+        rclcpp::rclcpp
+        ${sensor_msgs_TARGETS}
+        ${OpenCV_LIBRARIES}
+)

--- a/VisionPilot/tests/middleware_interfaces/ros2_interface/camera_subscriber/test_camera_subscriber.cpp
+++ b/VisionPilot/tests/middleware_interfaces/ros2_interface/camera_subscriber/test_camera_subscriber.cpp
@@ -1,0 +1,117 @@
+// Runtime smoke for ROS2ImageSubscriber: publish synthetic frames and confirm the
+// encoding normalization — a bgra8 image (as CARLA's native --ros2 camera publishes)
+// must come out as a 3-channel CV_8UC3 BGR frame with the alpha dropped, while a
+// mono8 image must pass through unchanged (the documented grayscale path).
+#include <rclcpp/rclcpp.hpp>
+#include <camera_subscriber/ros2_to_opencv.hpp>
+
+#include <sensor_msgs/msg/image.hpp>
+#include <opencv2/opencv.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <thread>
+#include <tuple>
+
+namespace
+{
+
+int g_failures = 0;
+
+void check(const char* name, bool ok)
+{
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+// Publish `img` until the subscriber yields a frame accepted by `accept`, or the
+// deadline expires (discovery + delivery take a moment). `accept` filters out
+// stale frames from a previous case still in flight in the single-slot buffer.
+template <typename AcceptFn>
+std::tuple<bool, cv::Mat> publish_and_receive(
+    const rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr& pub,
+    const rclcpp::Node::SharedPtr& pub_node,
+    camera_interface::ROS2ImageSubscriber& subscriber,
+    const sensor_msgs::msg::Image& img,
+    AcceptFn&& accept)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline) {
+        pub->publish(img);
+        rclcpp::spin_some(pub_node);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        auto [got, frame] = subscriber.get_latest_frame();
+        if (got && accept(frame)) return {true, frame};
+    }
+    return {false, cv::Mat()};
+}
+
+}  // namespace
+
+int main()
+{
+    const std::string topic = "/camera/image";
+    const int W = 4, H = 2;
+
+    // Subscriber under test (owns rclcpp::init, spins in the background).
+    camera_interface::ROS2ImageSubscriber subscriber(topic);
+
+    // Publisher on a matching QoS: the subscriber uses best-effort / volatile / KeepLast.
+    auto pub_node = std::make_shared<rclcpp::Node>("test_camera_publisher");
+    auto qos = rclcpp::QoS(rclcpp::KeepLast(1)).best_effort().durability_volatile();
+    auto pub = pub_node->create_publisher<sensor_msgs::msg::Image>(topic, qos);
+
+    // Case 1: bgra8, every pixel B=10 G=20 R=30 A=40 — alpha must be dropped.
+    sensor_msgs::msg::Image bgra;
+    bgra.width = W;
+    bgra.height = H;
+    bgra.encoding = "bgra8";
+    bgra.is_bigendian = 0;
+    bgra.step = W * 4;
+    bgra.data.resize(static_cast<size_t>(bgra.step) * H);
+    for (size_t i = 0; i < bgra.data.size(); i += 4) {
+        bgra.data[i + 0] = 10;  // B
+        bgra.data[i + 1] = 20;  // G
+        bgra.data[i + 2] = 30;  // R
+        bgra.data[i + 3] = 40;  // A
+    }
+
+    auto [got_bgra, frame_bgra] = publish_and_receive(
+        pub, pub_node, subscriber, bgra, [](const cv::Mat&) { return true; });
+    check("bgra8 frame received", got_bgra);
+    if (got_bgra) {
+        check("bgra8 -> 3-channel BGR (CV_8UC3, alpha dropped)", frame_bgra.type() == CV_8UC3);
+        check("bgra8 dimensions preserved", frame_bgra.cols == W && frame_bgra.rows == H);
+        const cv::Vec3b px = frame_bgra.at<cv::Vec3b>(0, 0);
+        check("bgra8 pixel BGR = (10, 20, 30)", px[0] == 10 && px[1] == 20 && px[2] == 30);
+    }
+
+    // Case 2: mono8, every pixel 77 — must pass through as single-channel.
+    sensor_msgs::msg::Image mono;
+    mono.width = W;
+    mono.height = H;
+    mono.encoding = "mono8";
+    mono.is_bigendian = 0;
+    mono.step = W;
+    mono.data.assign(static_cast<size_t>(mono.step) * H, 77);
+
+    // Skip late bgra8 leftovers (identified by the case-1 pixel pattern); a broken
+    // mono passthrough (converted to 3-channel gray) is NOT skipped and fails below.
+    auto [got_mono, frame_mono] = publish_and_receive(
+        pub, pub_node, subscriber, mono, [](const cv::Mat& f) {
+            return f.type() != CV_8UC3 || f.at<cv::Vec3b>(0, 0) != cv::Vec3b(10, 20, 30);
+        });
+    check("mono8 frame received", got_mono);
+    if (got_mono) {
+        check("mono8 passes through single-channel (CV_8UC1)", frame_mono.type() == CV_8UC1);
+        check("mono8 dimensions preserved", frame_mono.cols == W && frame_mono.rows == H);
+        check("mono8 pixel value preserved", frame_mono.at<uint8_t>(0, 0) == 77);
+    }
+
+    std::printf("\n%s (%d failure%s)\n", g_failures ? "FAILED" : "ALL PASS", g_failures,
+                g_failures == 1 ? "" : "s");
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

This PR implements the fixes described in #371, one commit per defect, so each change can be reviewed and reverted independently. Closes #371.

Vision Pilot advertises a ROS 2 interface as its integration point for real vehicles and simulators, but on current main that path cannot be used from a stock clone: the tree does not compile with `-DENABLE_ROS2_INTERFACE=ON`, and once the build is patched locally the default configuration cannot control a vehicle and crashes mid drive on common camera encodings. Because the ROS 2 code is compiled out by default, refactors on main keep breaking it silently. This PR repairs that path and adds the first tests that cover it, so the breakage becomes visible in any future change.

## Commits

| Commit | Title | What it does |
|---|---|---|
| ca216835 | fix: compile with ENABLE_ROS2_INTERFACE=ON | Adds the missing `camera_subscriber/ros2_to_opencv.hpp` include, qualifies `camera_interface::ROS2ImageSubscriber`, and reads `cfg.source.input_camera_topic` from its new location, in the app and the app test. |
| 5f2a9ba8 | fix: make the cv_bridge include portable across ROS 2 Humble and Jazzy | Selects `cv_bridge/cv_bridge.hpp` or `.h` with `__has_include`; Humble ships only the `.h` header and Jazzy only the `.hpp`. |
| 3b1f3ec2 | fix: acceleration topic default collided with steering topic | Defaults `vehicle_acceleration_topic` to `/vehicle/throttle_cmd` instead of `/vehicle/steering_cmd`, and adds `test_config` locking the ROS 2 topic defaults. |
| bd034e29 | fix: normalize incoming ROS2 images to bgr8, keep mono passthrough | Converts color encodings to `bgr8` in the camera subscriber while `mono8`/`mono16` pass through unchanged, and adds `test_camera_subscriber` covering both paths. |
| 451162c3 | fix: speed HUD blend weights washed out the frame | Blends the speed HUD with weights 0.85/0.15 that sum to 1.0, like the other overlays in the file. |
| 61e3a8e7 | fix: resolve ROS2 imported targets in camera_interface scope (Humble) | Adds `find_package(rclcpp REQUIRED)` in the `camera_interface` CMake scope so Humble can resolve the propagated `fastcdr` imported target at generate time. |

## What was broken and how to reproduce it

**1. The tree does not compile with the ROS 2 interface enabled.** Reproduce: fresh clone, `cmake -B build -DENABLE_ROS2_INTERFACE=ON` and build. `app/vision_pilot.cpp` and `tests/app/test_vision_pilot.cpp` reference `ROS2ImageSubscriber` without its `camera_interface` namespace, miss the `camera_subscriber/ros2_to_opencv.hpp` include, and read `cfg.input_camera_topic`, which moved into `SourceConfig`. Fixed in commit 1.

**2. The cv_bridge include breaks one distro or the other.** Reproduce: build with the flag on Ubuntu 24.04 with ROS 2 Jazzy, which ships only `cv_bridge/cv_bridge.hpp`, while the code includes `cv_bridge/cv_bridge.h`. The issue proposed re applying the plain `.hpp` include from #351, but during validation we found that Humble ships only the `.h` header, so that literal fix would just move the breakage to Ubuntu 22.04. Commit 2 selects the header with a C++17 `__has_include`, so the same source builds on both supported distros.

**3. On Humble, CMake generation fails with `Target "fastcdr" not found`.** This is a sixth defect we found while validating on both distros; it is not in the issue because the issue was validated on Jazzy only. Reproduce: `ros:humble` container, configure with the flag on. The `camera_interface` scope links `camera_subscriber`, which propagates rclcpp imported targets, but has no `find_package` of its own; imported targets are directory scoped and Humble's fastrtps export uses a generator expression that fails when the target is missing. Commit 6 adds `find_package(rclcpp REQUIRED)` in that scope, matching what the app and test scopes already do.

**4. Steering and acceleration commands share one topic by default.** Reproduce: run the binary with a conf that does not set `vehicle_acceleration_topic`, and echo `/vehicle/steering_cmd`: steering and throttle values interleave on the same topic, and any downstream bridge receives a stream it cannot tell apart, so the vehicle cannot be controlled. The default was a copy and paste slip in `vision_pilot_config.cpp`; the bug is masked by any deployment that sets the key explicitly, which is why it survived. Commit 3 changes the default to `/vehicle/throttle_cmd` and adds `test_config`, which locks all four ROS 2 topic defaults and asserts the steering and acceleration topics differ.

**5. Camera frames keep their source encoding and crash the pipeline mid drive.** Reproduce: feed the app any camera that does not publish `bgr8`, for example CARLA's native ros2 bridge which publishes `bgra8`. `toCvCopy(msg, msg->encoding)` is a no op conversion, so a 4 channel frame flows downstream; inference happens to tolerate it, and the app dies roughly 30 seconds into a run with a `cv::Exception` at the first HUD blend in the visualization. That makes it a latent mid drive crash rather than a startup failure, which is worse in practice. Commit 4 converts color encodings to `bgr8` and keeps the documented `mono8`/`mono16` passthrough intact, and adds `test_camera_subscriber`, which publishes synthetic `bgra8` and `mono8` images and asserts the exact output types and pixel values.

**6. The speed HUD washes the frame out.** Reproduce: enable visualization with a speed source active; `draw_speed` blends with weights summing to 1.5, so every pixel is scaled by 1.5 on each draw and the image saturates toward white. Commit 5 uses 0.85/0.15, matching the other overlays in the file that already sum to 1.0.

## Why this is worth taking

None of these changes contain anything simulator specific; they repair the generic ROS 2 contract of the application (compile, one command per topic, `bgr8` in, sane visualization) and they are the smallest diffs that do so: 12 files, about 30 lines outside the new tests. With them, a stock clone builds with the interface enabled on both supported distros and drives a vehicle closed loop from any ROS 2 camera and actuation bridge with no source patches, which we validated live against CARLA 0.9.16 through its native ros2 bridge (see #371 and #372, which deliberately depends on these fixes). The two new tests give the ROS 2 path its first regression coverage, so the next config or interface refactor cannot silently break it again.

## Validation

Both distros, both configurations, in clean `ros:humble` (Ubuntu 22.04) and `ros:jazzy` (Ubuntu 24.04) containers:

| | ROS2 OFF | ROS2 ON | test_config | test_camera_subscriber |
|---|---|---|---|---|
| Humble | build green | build green | 7/7 pass | 8/8 pass |
| Jazzy | build green | build green | 7/7 pass | 8/8 pass |

Zero compiler warnings in the touched files on all four builds; `test_planning` also ran clean on both distros.
