### PR TITLE
feat(simulation): adapt the CARLA ROS2 drive to the official VisionPilot Docker image

### DIFF
--- a/Simulation/CARLA/ROS2/README.md
+++ b/Simulation/CARLA/ROS2/README.md
@@ -7,12 +7,13 @@ Drive a CARLA ego **camera-only** with the single-binary VisionPilot closed loop
 publish identical topic names, so only the ego blueprint, launcher and CARLA wheel differ.
 
 **CARLA always runs on the HOST (from `$CARLA_ROOT`), never in Docker.** Only VisionPilot
-and the control bridge run in the dev container (`autoware-visionpilot-dev:cuda`).
+and the control bridge run in a container — the **official VisionPilot image**
+(`visionpilot:gpu-ros2`, built by `VisionPilot/docker/build.sh --gpu --ros2`).
 
 ```text
 HOST:  CARLA --ros2 (windowed)  +  ros_carla_config.py (spawn ego/camera — pure PythonAPI, no ROS)
 CONTAINERS (one DDS domain — ROS never crosses the host/container boundary):
-  /carla/hero/main_cam/image ── sensor_msgs/Image (CARLA native) ──►  VisionPilot (camera_subscriber)
+  /carla/hero/main_cam/image ── sensor_msgs/Image (CARLA native) ──►  VisionPilot (camera_ros2_interface)
   ego_telemetry (bridge ctr, PythonAPI over TCP:2000)
       ├─ /vehicle/speed (Float64 m/s) ──► VisionPilot planner + bridge watchdog
       └─ /carla_bridge/max_steer_angle (latched, rad) ──► bridge
@@ -50,8 +51,8 @@ feeding VisionPilot the real speed is safe at any `speed_limit`.
 | `config/visionpilot.carla.conf`, `config/visionpilot_ros2.carla.conf` | VisionPilot run-config overlay (ros2 source, sim `speed_limit`/`Lf`, `/vehicle/*` topics)                                                                                                                  |
 | `config/H_carla.yaml`                                                 | main_cam ground homography (camera → world)                                                                                                                                                                |
 | `gen_carla_C_matrix.py`                                               | derive preprocess C from `H_carla.yaml` (reuses VisionPilot logic) → `config/homography_C_matrix.yaml` (gitignored)                                                                                        |
-| `run_visionpilot.sh`                                                  | run VisionPilot in the dev container, bind-mounting the CARLA config over the paths the binary reads                                                                                                       |
-| `build_bridge.sh`                                                     | colcon-build the bridge (`carla_msgs` + `visionpilot_carla_bridge`)                                                                                                                                        |
+| `run_visionpilot.sh`                                                  | run VisionPilot from the official image (`visionpilot:gpu-ros2`), bind-mounting the CARLA config over the paths the binary reads                                                                           |
+| `build_bridge.sh`                                                     | colcon-build the bridge (`carla_msgs` + `visionpilot_carla_bridge`) — host ROS 2 Jazzy or a `ros:jazzy` container                                                                                          |
 | `carla_speed_monitor.py`                                              | optional debug tool: ground-truth speed + collision printer (PythonAPI)                                                                                                                                    |
 
 > **Camera FOV is 60°, not the model's ~42° view.** The homography warp reprojects the camera
@@ -67,9 +68,13 @@ feeding VisionPilot the real speed is safe at any `speed_limit`.
    **no ROS needed on the host**. The wheel is staged onto `PYTHONPATH` automatically and
    shadows any other installed `carla` package (also staged for the container's python 3.12,
    which runs `ego_telemetry`).
-3. The dev image `autoware-visionpilot-dev:cuda` (`Docker/build.sh`).
-4. VisionPilot built with the ROS 2 interface, inside the container:
-   `Docker/run.sh --test` (builds `VisionPilot/build_docker_ros2/`).
+3. The official VisionPilot image with ROS 2 + GPU support:
+   `cd VisionPilot/docker && ./build.sh --gpu --ros2` → `visionpilot:gpu-ros2`
+   (compiles the binary with `-DENABLE_ROS2_INTERFACE=ON` and bakes it at
+   `/usr/bin/VisionPilot` together with the config and the model weights — make sure the
+   `.onnx` weights are present under `VisionPilot/modules/models/weights/` **before** building).
+4. `docker` able to pull `ros:jazzy` (used once by `drive.sh` to colcon-build the bridge —
+   the official image ships no build tools).
 5. An X display for the CARLA + VisionPilot windows (default `:1`; live runs are always windowed).
 
 ## Run
@@ -80,12 +85,12 @@ feeding VisionPilot the real speed is safe at any `speed_limit`.
 ./drive.sh down      # ALWAYS run between experiments — stale actors/DDS topics corrupt the next run
 ```
 
-Knobs (env): `CARLA_ROOT`, `RIG_JSON`, `SPAWN_PYTHON`, `SPAWN_INDEX`, `DISPLAY`, `IMAGE`.
-Drive speed: `speed_limit` in `config/visionpilot.carla.conf` (m/s).
+Knobs (env): `CARLA_ROOT`, `RIG_JSON`, `SPAWN_PYTHON`, `SPAWN_INDEX`, `DISPLAY`, `IMAGE`,
+`BRIDGE_IMAGE`. Drive speed: `speed_limit` in `config/visionpilot.carla.conf` (m/s).
 
-The CARLA run config is **bind-mounted** into the container over the fixed CWD-relative paths the
-binary reads (`config/vision_pilot.conf`, `config/vision_pilot_ros2.conf`,
-`config/homography_C_matrix.yaml`, and `H_carla.yaml` over `config/H.yaml` — without that last
+The CARLA run config is **bind-mounted** into the container over the official-image paths the
+binary reads (`/usr/share/visionpilot/config/vision_pilot.conf`, `.../vision_pilot_ros2.conf`,
+`.../homography_C_matrix.yaml`, and `H_carla.yaml` over `.../H.yaml` — without that last
 mount AutoSteer fits 0 lane points); the tracked `VisionPilot/` tree is left pristine.
 
 All ROS 2 processes run with `FASTDDS_BUILTIN_TRANSPORTS=UDPv4` (host↔container Fast-DDS shared

--- a/Simulation/CARLA/ROS2/build_bridge.sh
+++ b/Simulation/CARLA/ROS2/build_bridge.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # Build the VisionPilot<->CARLA bridge (carla_msgs + visionpilot_carla_bridge).
 #
-# Agnostic: runs identically on a host with ROS 2 Jazzy or inside the VisionPilot
-# dev container. Builds only the two bridge packages (--packages-select) so the
-# legacy shared-memory packages under src/ are skipped.
+# Agnostic: runs identically on a host with ROS 2 Jazzy or in any colcon-capable
+# container (the official VisionPilot image ships no colcon — drive.sh uses ros:jazzy).
+# Builds only the two bridge packages (--packages-select).
 #
 #   # host:
 #   ./build_bridge.sh
-#   # dev container:
-#   ../../../Docker/run.sh -- bash -lc 'cd /workspace/Simulation/CARLA/ROS2 && ./build_bridge.sh'
+#   # container (what drive.sh does):
+#   docker run --rm -v "$(git rev-parse --show-toplevel)":/workspace \
+#       -w /workspace/Simulation/CARLA/ROS2 ros:jazzy bash -lc './build_bridge.sh'
 set -euo pipefail
 
 WS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/Simulation/CARLA/ROS2/build_bridge.sh
+++ b/Simulation/CARLA/ROS2/build_bridge.sh
@@ -24,6 +24,18 @@ if [ -f "${ROS_SETUP}" ]; then
 fi
 
 cd "${WS_DIR}"
+
+# A build tree created under a different mount prefix (host vs /ws vs /workspace)
+# poisons CMakeCache and colcon fails; detect and start clean.
+for cache in build/*/CMakeCache.txt; do
+    [ -f "$cache" ] || continue
+    if ! grep -q "=${WS_DIR}/build/" "$cache"; then
+        echo "[build_bridge] stale build tree (different mount prefix) — cleaning build/ install/"
+        rm -rf build install
+        break
+    fi
+done
+
 colcon build --packages-select carla_msgs visionpilot_carla_bridge "$@"
 
 echo "[build_bridge] done. Source the overlay with:"

--- a/Simulation/CARLA/ROS2/drive.sh
+++ b/Simulation/CARLA/ROS2/drive.sh
@@ -119,9 +119,11 @@ up() {
     sleep 5 # let the world settle before API connections
 
     echo "[up] 2/4 spawn helper (host, pure PythonAPI) — rig $(basename "$RIG_JSON") — log: $SPAWN_LOG"
+    # env(1) is required: assignments produced by ${VAR:+...} expansion are not
+    # recognized as prefix assignments by the shell (they become command words).
     (cd "$HERE" &&
-        PYTHONPATH="$PKG_DIR/$host_pytag${PYTHONPATH:+:$PYTHONPATH}" \
-            ${SPAWN_INDEX:+SPAWN_INDEX=$SPAWN_INDEX} \
+        env PYTHONPATH="$PKG_DIR/$host_pytag${PYTHONPATH:+:$PYTHONPATH}" \
+            ${SPAWN_INDEX:+SPAWN_INDEX="$SPAWN_INDEX"} \
             "$SPAWN_PYTHON" ros_carla_config.py -f "$RIG_JSON" >"$SPAWN_LOG" 2>&1) &
     sleep 6
     pgrep -f ros_carla_config.py >/dev/null || die "spawn helper died — see $SPAWN_LOG"

--- a/Simulation/CARLA/ROS2/drive.sh
+++ b/Simulation/CARLA/ROS2/drive.sh
@@ -6,8 +6,11 @@
 #             1. CARLA server  — on the HOST, from $CARLA_ROOT, WINDOWED (never offscreen)
 #             2. spawn helper  — on the HOST (ros_carla_config.py: ego + main_cam; pure
 #                                PythonAPI, NO ROS — host needs no rclpy)
-#             3. bridge build  — one-shot colcon build of visionpilot_carla_bridge
-#             4. VisionPilot + bridge — ONE dev container, graphic mode (run_visionpilot.sh
+#             3. bridge build  — one-shot colcon build of visionpilot_carla_bridge in a
+#                                ros:jazzy container (the official VisionPilot image ships
+#                                no colcon)
+#             4. VisionPilot + bridge — ONE container from the OFFICIAL VisionPilot image
+#                                (visionpilot:gpu-ros2), graphic mode (run_visionpilot.sh
 #                                launches the control relay + ego_telemetry beside the binary:
 #                                cross-container DDS delivery proved unreliable, so every ROS 2
 #                                node we own shares a single container)
@@ -23,7 +26,8 @@
 #                 is staged automatically from $CARLA_ROOT (default: python3)
 #   DISPLAY       X display for CARLA + VisionPilot windows (default: :1)
 #   SPAWN_INDEX   spawn-point override (default: "spawn_index" in RIG_JSON)
-#   IMAGE         dev-container image            (default: autoware-visionpilot-dev:cuda)
+#   IMAGE         official VisionPilot image     (default: visionpilot:gpu-ros2)
+#   BRIDGE_IMAGE  colcon-capable image for the bridge build (default: ros:jazzy)
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # .../Simulation/CARLA/ROS2
 ROOT="$(cd "$HERE/../../.." && pwd)"                 # repo root
@@ -31,7 +35,8 @@ CARLA_ROOT="${CARLA_ROOT:-$HOME/CARLA_0.9.16}"
 RIG_JSON="${RIG_JSON:-$HERE/config/VisionPilot_carla916.json}"
 SPAWN_PYTHON="${SPAWN_PYTHON:-python3}"
 DISPLAY="${DISPLAY:-:1}"
-IMAGE="${IMAGE:-autoware-visionpilot-dev:cuda}"
+IMAGE="${IMAGE:-visionpilot:gpu-ros2}"
+BRIDGE_IMAGE="${BRIDGE_IMAGE:-ros:jazzy}"
 PKG_DIR="$HERE/.carla_pkg" # staged CARLA wheel (gitignored)
 CARLA_LOG=/tmp/carla_server.log
 SPAWN_LOG=/tmp/carla_spawn.log
@@ -81,7 +86,7 @@ stage_carla_wheel() {
     fi
 }
 
-# Python tag of the dev container (Ubuntu 24.04 -> 3.12); ego_telemetry runs there.
+# Python tag of the official image (Ubuntu 24.04 -> 3.12); ego_telemetry runs there.
 CONTAINER_PYTAG=cp312
 
 up() {
@@ -94,7 +99,8 @@ up() {
         launcher="$CARLA_ROOT/CarlaUnreal.sh" # 0.10
     else die "no CarlaUE4.sh / CarlaUnreal.sh in $CARLA_ROOT"; fi
     [ -f "$RIG_JSON" ] || die "rig json '$RIG_JSON' not found"
-    docker image inspect "$IMAGE" >/dev/null 2>&1 || die "image '$IMAGE' missing — Docker/build.sh"
+    docker image inspect "$IMAGE" >/dev/null 2>&1 ||
+        die "image '$IMAGE' missing — build it: cd VisionPilot/docker && ./build.sh --gpu --ros2"
     local host_pytag
     host_pytag="$("$SPAWN_PYTHON" -c 'import sys; print("cp%d%d" % sys.version_info[:2])')"
     stage_carla_wheel "$host_pytag"      # spawn helper (host)
@@ -120,10 +126,10 @@ up() {
     sleep 6
     pgrep -f ros_carla_config.py >/dev/null || die "spawn helper died — see $SPAWN_LOG"
 
-    echo "[up] 3/4 building the bridge (one-shot container)"
+    echo "[up] 3/4 building the bridge (one-shot $BRIDGE_IMAGE container)"
     docker run --rm --name vp_bridge_build \
         -v "$ROOT":/workspace -w /workspace/Simulation/CARLA/ROS2 \
-        "$IMAGE" bash -lc 'source /opt/ros/jazzy/setup.bash && ./build_bridge.sh' >/dev/null
+        "$BRIDGE_IMAGE" bash -lc './build_bridge.sh' >/dev/null
 
     echo "[up] 4/4 VisionPilot + bridge (one container vp_drive, graphic) — ./drive.sh down to stop"
     DISPLAY="$DISPLAY" "$HERE/run_visionpilot.sh"
@@ -134,7 +140,7 @@ up) up ;;
 down) down ;;
 status) status ;;
 *)
-    echo "usage: $0 {up|down|status}   (env: CARLA_ROOT RIG_JSON SPAWN_PYTHON DISPLAY SPAWN_INDEX IMAGE)"
+    echo "usage: $0 {up|down|status}   (env: CARLA_ROOT RIG_JSON SPAWN_PYTHON DISPLAY SPAWN_INDEX IMAGE BRIDGE_IMAGE)"
     exit 2
     ;;
 esac

--- a/Simulation/CARLA/ROS2/gen_carla_C_matrix.py
+++ b/Simulation/CARLA/ROS2/gen_carla_C_matrix.py
@@ -4,7 +4,7 @@
 Reuses VisionPilot's committed C-derivation (the fixed model-view V and
 find_homography_C_matrix) without modifying VisionPilot. Writes the result next to
 this script's config/, which the drive bind-mounts (read-only) over
-/workspace/VisionPilot/config/homography_C_matrix.yaml.
+/usr/share/visionpilot/config/homography_C_matrix.yaml in the official image.
 
     python3 gen_carla_C_matrix.py            # config/H_carla.yaml -> config/homography_C_matrix.yaml
 """
@@ -16,7 +16,10 @@ import cv2
 
 ROOT = Path(__file__).resolve().parents[3]  # repo root
 sys.path.insert(0, str(ROOT / "VisionPilot" / "scripts"))
-from find_homography_C_matrix import find_homography_C_matrix, load_homography_H_matrix  # noqa: E402
+from find_homography_C_matrix import (  # noqa: E402
+    find_homography_C_matrix,
+    load_homography_H_matrix,
+)
 
 
 def main() -> None:

--- a/Simulation/CARLA/ROS2/run_visionpilot.sh
+++ b/Simulation/CARLA/ROS2/run_visionpilot.sh
@@ -1,27 +1,34 @@
 #!/usr/bin/env bash
 # Run VisionPilot against the CARLA ego WITHOUT modifying VisionPilot/.
 #
-# The binary loads config/vision_pilot{,_ros2}.conf and config/homography_C_matrix.yaml
-# relative to its CWD (/workspace/VisionPilot) and ignores --config. Instead of copying the
-# CARLA variants into the tracked tree, we bind-mount them (read-only) over those exact paths,
-# so the host VisionPilot/ stays pristine. The C matrix is (re)generated from H_carla.yaml first.
+# Uses the OFFICIAL VisionPilot image (visionpilot:gpu-ros2, built by
+# VisionPilot/docker/build.sh --gpu --ros2): the binary is baked at /usr/bin/VisionPilot
+# with its config + model weights under /usr/share/visionpilot/. The binary resolves
+# config/<file> relative to its workdir, falling back to /usr/share/visionpilot/config/
+# (modules/common/src/utils.cpp), so the CARLA variants are bind-mounted (read-only)
+# over those exact paths — the tracked VisionPilot/ tree stays pristine. The C matrix
+# is (re)generated from H_carla.yaml first.
 #
-# The CARLA bridge (control relay + ego_telemetry) runs INSIDE this same container, launched
-# before the binary: cross-container Fast-DDS delivery (bridge -> VP /vehicle/speed) proved
-# unreliable — it died after discovery, leaving VP speed-blind. One container = one DDS host.
+# The CARLA bridge (control relay + ego_telemetry) runs INSIDE this same container,
+# launched before the binary: cross-container Fast-DDS delivery (bridge -> VP
+# /vehicle/speed) proved unreliable — it died after discovery, leaving VP speed-blind.
+# One container = one DDS host. The bridge install/ is colcon-built beforehand
+# (build_bridge.sh in a ros:jazzy container; drive.sh does it) and mounted from the repo.
 #
-# Prereqs (see README.md): VisionPilot built with -DENABLE_ROS2_INTERFACE=ON into
-# VisionPilot/build_docker_ros2/ (Docker/run.sh --test builds it), the bridge colcon-built
-# (build_bridge.sh), the CARLA cp312 wheel staged (drive.sh does all of that), CARLA + ego up.
-# Override IMAGE / VP_BIN / DISPLAY via env.
-# NOTE: DISPLAY defaults to :1 here (live sim display); Docker/run.sh defaults to :0.
+# Prereqs (see README.md): the visionpilot:gpu-ros2 image, the bridge colcon-built,
+# the CARLA cp312 wheel staged (drive.sh does all of that), CARLA + ego up.
+# Env overrides: IMAGE, VP_BIN, DISPLAY, VP_CONF, VP_ROS2_CONF.
+# NOTE: DISPLAY defaults to :1 here (live sim display).
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # .../Simulation/CARLA/ROS2
 ROOT="$(cd "$HERE/../../.." && pwd)"                 # repo root
 CFG="$HERE/config"
-IMAGE="${IMAGE:-autoware-visionpilot-dev:cuda}"
-VP_BIN="${VP_BIN:-./build_docker_ros2/VisionPilot}"
+IMAGE="${IMAGE:-visionpilot:gpu-ros2}"
+VP_BIN="${VP_BIN:-/usr/bin/VisionPilot}"
 DISPLAY="${DISPLAY:-:1}"
+# Conf overrides let a headless/CPU smoke swap the drive conf without editing this script.
+VP_CONF="${VP_CONF:-$CFG/visionpilot.carla.conf}"
+VP_ROS2_CONF="${VP_ROS2_CONF:-$CFG/visionpilot_ros2.carla.conf}"
 
 die() {
     echo "run_visionpilot: ERROR: $*" >&2
@@ -30,14 +37,11 @@ die() {
 
 # ── Fail fast on every hidden prerequisite ────────────────────────────────────
 docker image inspect "$IMAGE" >/dev/null 2>&1 ||
-    die "image '$IMAGE' not found — build it with Docker/build.sh"
-[ -x "$ROOT/VisionPilot/${VP_BIN#./}" ] ||
-    die "VisionPilot binary missing at VisionPilot/${VP_BIN#./} — build it first:
-  Docker/run.sh --test    # or: cmake -B build_docker_ros2 -DENABLE_ROS2_INTERFACE=ON && cmake --build build_docker_ros2"
-for f in visionpilot.carla.conf visionpilot_ros2.carla.conf H_carla.yaml; do
-    # H_carla.yaml is mounted over config/H.yaml — without it AutoSteer silently fits 0 lane points.
-    [ -f "$CFG/$f" ] || die "missing $CFG/$f"
-done
+    die "image '$IMAGE' not found — build it: cd VisionPilot/docker && ./build.sh --gpu --ros2"
+[ -f "$VP_CONF" ] || die "missing conf $VP_CONF"
+[ -f "$VP_ROS2_CONF" ] || die "missing conf $VP_ROS2_CONF"
+# H_carla.yaml is mounted over config/H.yaml — without it AutoSteer silently fits 0 lane points.
+[ -f "$CFG/H_carla.yaml" ] || die "missing $CFG/H_carla.yaml"
 [ -d "$HERE/.carla_pkg/cp312/carla" ] ||
     die "CARLA cp312 wheel not staged at .carla_pkg/cp312 (ego_telemetry needs it) — run drive.sh up"
 [ -f "$HERE/install/setup.bash" ] ||
@@ -52,18 +56,19 @@ python3 "$HERE/gen_carla_C_matrix.py"
 DISPLAY="$DISPLAY" xhost +local: >/dev/null 2>&1 || true
 
 # 3) run bridge + VisionPilot in ONE container (single DDS host); bind-mount the CARLA config
-#    over the paths the binary reads (VP/ untouched)
+#    over the official-image paths the binary reads (VP/ untouched). The repo is mounted only
+#    for the bridge install/ overlay and the staged CARLA wheel.
 exec docker run --rm --name vp_drive --gpus all --net=host --ipc=host \
     -e DISPLAY="$DISPLAY" -e QT_QPA_PLATFORM=xcb -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e FASTDDS_BUILTIN_TRANSPORTS=UDPv4 -e CUDA_CACHE_PATH=/cache -e CUDA_CACHE_MAXSIZE=2147483648 \
     -e PYTHONPATH=/opt/carla_python \
     -v "$HERE/.carla_pkg/cp312":/opt/carla_python:ro \
-    -v "$HOME/.cache/vp_cuda:/cache" -v "$ROOT":/workspace -w /workspace/VisionPilot \
-    -v "$CFG/visionpilot.carla.conf:/workspace/VisionPilot/config/vision_pilot.conf:ro" \
-    -v "$CFG/visionpilot_ros2.carla.conf:/workspace/VisionPilot/config/vision_pilot_ros2.conf:ro" \
-    -v "$CFG/homography_C_matrix.yaml:/workspace/VisionPilot/config/homography_C_matrix.yaml:ro" \
-    -v "$CFG/H_carla.yaml:/workspace/VisionPilot/config/H.yaml:ro" \
-    "$IMAGE" bash -lc "
+    -v "$HOME/.cache/vp_cuda:/cache" -v "$ROOT":/workspace -w /usr/share/visionpilot \
+    -v "$VP_CONF:/usr/share/visionpilot/config/vision_pilot.conf:ro" \
+    -v "$VP_ROS2_CONF:/usr/share/visionpilot/config/vision_pilot_ros2.conf:ro" \
+    -v "$CFG/homography_C_matrix.yaml:/usr/share/visionpilot/config/homography_C_matrix.yaml:ro" \
+    -v "$CFG/H_carla.yaml:/usr/share/visionpilot/config/H.yaml:ro" \
+    --entrypoint bash "$IMAGE" -lc "
         source /opt/ros/jazzy/setup.bash
         source /workspace/Simulation/CARLA/ROS2/install/setup.bash
         ros2 launch visionpilot_carla_bridge carla_bridge.launch.py &


### PR DESCRIPTION
## What

The CARLA ROS2 integration under Simulation/CARLA/ROS2 predates the official Docker support and still launched a retired local dev container with a bind mounted out of tree build. This PR repoints the drive orchestration to the image this repo actually ships, with zero changes inside VisionPilot/:

- run_visionpilot.sh now runs the official image (docker/build.sh --gpu --ros2, tag visionpilot:gpu-ros2), bind mounts the CARLA config overlay over the /usr/share/visionpilot/config paths the binary resolves, and execs the installed /usr/bin/VisionPilot through an entrypoint override that co launches the control bridge in the same container (one container, one DDS host).
- drive.sh builds the bridge in a ros:jazzy container since the official image ships no build tools (new BRIDGE_IMAGE knob), and the SPAWN_INDEX override is routed through env(1) because an assignment produced by shell expansion is not parsed as a prefix assignment.
- build_bridge.sh detects a colcon tree built under a different mount prefix and cleans it before building, which otherwise fails on a poisoned CMakeCache.
- README and helper docstrings updated to the new flow.

## Validation

Headless (no CARLA server): the bridge colcon builds in ros:jazzy and runs in ros-jazzy-ros-base, and the adapted script brings up VisionPilot plus relay plus ego_telemetry with the full ROS2 graph connected (camera subscription, Float64 steering and throttle publications into the relay, CarlaEgoVehicleControl out).

Live (CARLA 0.9.16, GPU): full closed loop drive with the unmodified binary from the official image, 31 to 38 fps on CUDA, stable lane centering around 0.1 to 0.2 m cross track error, vehicle reached 7.8 m/s. The known limitation hit during these runs is the lateral MPC limit cycle at speed, reported separately in #380 (the Docker CPU variant issue found on the way is #381). Both are core VisionPilot topics and intentionally out of scope here.
