### PR TITLE
feat(ros2): publish fused lane center as nav_msgs/Path on /vehicle/lane_path

### DIFF
--- a/VisionPilot/app/vision_pilot.cpp
+++ b/VisionPilot/app/vision_pilot.cpp
@@ -160,6 +160,12 @@ int main(int argc, char** argv)
                 cipo_dist,
                 r->cipo.velocity_ms);
 
+            vehicle_interface->publish_lane_path(
+                camera_interface->get_latest_frame_stamp_sec(),
+                r->lateral.valid,
+                r->lateral.cte_m, r->lateral.yaw_rad, r->lateral.curvature,
+                r->lateral.path_valid, r->lateral.path_x_max_m);
+
             vehicle_interface->write(
                 plan.steering.empty() ? 0.0 : plan.steering[0],
                 plan.acceleration);

--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_ros2_interface/include/camera_ros2_interface/camera_ros2_interface.hpp
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_ros2_interface/include/camera_ros2_interface/camera_ros2_interface.hpp
@@ -70,6 +70,7 @@ public:
     */
     std::tuple<bool, cv::Mat> get_latest_frame();
 
+    double get_latest_frame_stamp_sec() const override;
 
     // /**
     // * @brief Get latest frame with frame metadata, via timestamp and frame index
@@ -155,6 +156,8 @@ private:
     mutable std::mutex frame_mutex;
     cv::Mat latest_frame;
     bool has_latest_frame = false;
+    double latest_stamp_sec_ = -1.0;    // stamp of the frame in the slot
+    double consumed_stamp_sec_ = -1.0;  // stamp of the last frame handed out
 
     // QoS settings for subscription
     // (KeepLast with hardcoded `depth=1` for single-slot retrieval)

--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_ros2_interface/src/camera_ros2_interface.cpp
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/camera_ros2_interface/src/camera_ros2_interface.cpp
@@ -104,6 +104,7 @@ void CameraRos2Interface::image_callback(
         // Store latest frame
         latest_frame = cv_image.clone(); // Clone to ensure independent memory
         has_latest_frame = true;
+        latest_stamp_sec_ = msg->header.stamp.sec + msg->header.stamp.nanosec * 1e-9;
     }
 };
 
@@ -146,6 +147,7 @@ std::tuple<bool, cv::Mat> CameraRos2Interface::get_latest_frame()
 
     // Fetch and consume latest frame
     cv::Mat frame = latest_frame.clone();
+    consumed_stamp_sec_ = latest_stamp_sec_;
     has_latest_frame = false;
     latest_frame.release();
 
@@ -201,6 +203,11 @@ void CameraRos2Interface::reset_stats()
     RCLCPP_INFO(node->get_logger(), "Statistics reset");
 };
 
+double CameraRos2Interface::get_latest_frame_stamp_sec() const
+{
+    std::lock_guard<std::mutex> lock(frame_mutex);
+    return consumed_stamp_sec_;
+};
 
 CameraRos2Interface::~CameraRos2Interface()
 {

--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/CMakeLists.txt
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.22.1)
 
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
 add_library(vehicle_ros2_interface
         src/vehicle_ros2_interface.cpp
@@ -17,4 +19,6 @@ target_link_libraries(vehicle_ros2_interface
         vehicle_interface
         rclcpp::rclcpp
         std_msgs::std_msgs__rosidl_generator_cpp
+        nav_msgs::nav_msgs__rosidl_generator_cpp
+        geometry_msgs::geometry_msgs__rosidl_generator_cpp
 )

--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/CMakeLists.txt
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/CMakeLists.txt
@@ -20,5 +20,7 @@ target_link_libraries(vehicle_ros2_interface
         rclcpp::rclcpp
         std_msgs::std_msgs__rosidl_generator_cpp
         nav_msgs::nav_msgs__rosidl_generator_cpp
+        nav_msgs::nav_msgs__rosidl_typesupport_cpp
         geometry_msgs::geometry_msgs__rosidl_generator_cpp
+        geometry_msgs::geometry_msgs__rosidl_typesupport_cpp
 )

--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/include/vehicle_ros2_interface/vehicle_ros2_interface.hpp
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/include/vehicle_ros2_interface/vehicle_ros2_interface.hpp
@@ -3,6 +3,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/float64.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <thread>
 #include <atomic>
 #include <functional>
@@ -15,6 +17,7 @@
 //
 //  Publish    /vehicle/steering_cmd    Float64   tyre angle (rad)
 //             /vehicle/throttle_cmd   Float64   acceleration (m/s²)
+//             /vehicle/lane_path      nav_msgs/Path  fused lane center (base_link)
 //
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -32,6 +35,12 @@ public:
     // Publish tyre angle (rad) and acceleration (m/s²) to ROS2.
     void write(double steering, double acceleration) override;
 
+    // Publish the fused lane center as nav_msgs/Path in base_link, stamped
+    // with the source image's sim time. Empty path = invalid frame.
+    void publish_lane_path(double stamp_sec, bool valid, double cte_m,
+                           double yaw_rad, double curvature, bool path_valid,
+                           double path_x_max) override;
+
 private:
     // Inner node — owns all ROS 2 concerns
     class VehicleRos2Node : public rclcpp::Node
@@ -46,6 +55,7 @@ private:
         rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr sub_;
         rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr steering_pub_;
         rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr throttle_pub_;
+        rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr lane_path_pub_;
     };
 
     std::shared_ptr<VehicleRos2Node> node_;

--- a/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/src/vehicle_ros2_interface.cpp
+++ b/VisionPilot/modules/middleware_interfaces/ros2_interface/vehicle_ros2_interface/src/vehicle_ros2_interface.cpp
@@ -1,4 +1,6 @@
 #include <string>
+#include <cmath>
+#include <algorithm>
 #include <vehicle_ros2_interface/vehicle_ros2_interface.hpp>
 
 // ── VehicleRos2Node ───────────────────────────────────────────────────────────
@@ -23,11 +25,13 @@ VehicleRos2Interface::VehicleRos2Node::VehicleRos2Node(
 
     steering_pub_ = create_publisher<std_msgs::msg::Float64>(vehicle_steering_topic, cmd_qos);
     throttle_pub_ = create_publisher<std_msgs::msg::Float64>(vehicle_acceleration_topic, cmd_qos);
+    lane_path_pub_ = create_publisher<nav_msgs::msg::Path>("/vehicle/lane_path", cmd_qos);
 
     RCLCPP_INFO(get_logger(), "VehicleRos2Interface ready");
     RCLCPP_INFO(get_logger(), "  sub  /vehicle/speed");
     RCLCPP_INFO(get_logger(), "  pub  /vehicle/steering_cmd");
     RCLCPP_INFO(get_logger(), "  pub  /vehicle/throttle_cmd");
+    RCLCPP_INFO(get_logger(), "  pub  /vehicle/lane_path");
 }
 
 // ── VehicleRos2Interface ──────────────────────────────────────────────────────
@@ -66,4 +70,40 @@ void VehicleRos2Interface::write(const double steering, const double acceleratio
     std_msgs::msg::Float64 throttle_msg;
     throttle_msg.data = acceleration;
     node_->throttle_pub_->publish(throttle_msg);
+}
+
+void VehicleRos2Interface::publish_lane_path(const double stamp_sec, const bool valid,
+                                             const double cte_m, const double yaw_rad,
+                                             const double curvature, const bool path_valid,
+                                             const double path_x_max)
+{
+    nav_msgs::msg::Path msg;
+    msg.header.frame_id = "base_link";
+    if (stamp_sec >= 0.0)
+    {
+        msg.header.stamp.sec = static_cast<int32_t>(stamp_sec);
+        msg.header.stamp.nanosec =
+            static_cast<uint32_t>((stamp_sec - msg.header.stamp.sec) * 1e9);
+    }
+    if (valid)
+    {
+        // Lane center as the quadratic the fused scalars describe (x fwd, y +left):
+        //   y(x) = (curvature/2)·x² + tan(yaw_rad)·x + cte_m
+        // cte_m is +ve when the ego sits right of the path, so the path lies at +y.
+        const double a = 0.5 * curvature;
+        const double b = std::tan(yaw_rad);
+        const double x_end = path_valid ? std::clamp(path_x_max, 10.0, 60.0) : 40.0;
+        for (double x = 0.0; x <= x_end; x += 1.0)
+        {
+            geometry_msgs::msg::PoseStamped p;
+            p.header = msg.header;
+            p.pose.position.x = x;
+            p.pose.position.y = a * x * x + b * x + cte_m;
+            const double yaw = std::atan(2.0 * a * x + b);
+            p.pose.orientation.z = std::sin(yaw / 2.0);
+            p.pose.orientation.w = std::cos(yaw / 2.0);
+            msg.poses.push_back(p);
+        }
+    }
+    node_->lane_path_pub_->publish(msg);
 }

--- a/VisionPilot/modules/sensing/camera_interface/include/camera_interface/camera_interface.hpp
+++ b/VisionPilot/modules/sensing/camera_interface/include/camera_interface/camera_interface.hpp
@@ -29,6 +29,10 @@ public:
     // {false, {}} = no frame yet (live) or stream ended (video, no loop).
     virtual std::tuple<bool, cv::Mat> get_latest_frame() = 0;
     virtual std::vector<std::string> get_overlay() const = 0;
+
+    // Sim-time stamp [s] of the frame returned by the last get_latest_frame().
+    // Negative when the source carries no timestamps (V4L2 / video file).
+    virtual double get_latest_frame_stamp_sec() const { return -1.0; }
 };
 
 #endif //VISIONPILOT_CAMERA_INTERFACE_HPP

--- a/VisionPilot/modules/sensing/vehicle_interface/include/vehicle_interface/vehicle_interface.hpp
+++ b/VisionPilot/modules/sensing/vehicle_interface/include/vehicle_interface/vehicle_interface.hpp
@@ -13,6 +13,15 @@ public:
 
     // Send steering and acceleration via CAN frame
     virtual void write(double steering, double acceleration) = 0;
+
+    // Publish the fused lane-center geometry (middleware-specific; default: none).
+    // Args mirror LateralFusionEstimate: cte_m +ve = ego right of path,
+    // yaw_rad +ve = path heading left, curvature +ve = left turn;
+    // stamp_sec = source-image time (negative = unknown).
+    virtual void publish_lane_path(double /*stamp_sec*/, bool /*valid*/,
+                                   double /*cte_m*/, double /*yaw_rad*/,
+                                   double /*curvature*/, bool /*path_valid*/,
+                                   double /*path_x_max*/) {}
 };
 
 


### PR DESCRIPTION
## Summary

Adds a `/vehicle/lane_path` publisher (`nav_msgs/Path`) to the ROS 2 vehicle interface so downstream consumers can follow VisionPilot's fused lane center as an explicit geometric path, rather than only consuming the raw steering command.

Every frame, the fused lateral estimate (`cte`, `yaw error`, `curvature`) is sampled into a `nav_msgs/Path` in the `base_link` frame, stamped with the source image's sim time. An empty path marks an invalid frame.

## Motivation

VisionPilot already emits a steering command on `/vehicle/steering_cmd`. Consuming that raw command directly couples the downstream controller to VisionPilot's internal steering law. Publishing the fused lane *geometry* as a standard `nav_msgs/Path` lets any trajectory-follower (e.g. an MPC lateral controller) track the lane center in its own frame with its own tuning — a cleaner, more reusable contract.

## What changed

- **`vehicle_interface`**: new `publish_lane_path(stamp_sec, valid, cte_m, yaw_rad, curvature, path_valid, path_x_max)` virtual on the base interface, defaulting to a no-op so non-ROS 2 interfaces are unaffected.
- **`vehicle_ros2_interface`**: publishes the fused lane center on `/vehicle/lane_path`. The path is the quadratic the fused scalars describe, `y(x) = (curvature/2)·x² + tan(yaw)·x + cte`, sampled at 1 m spacing over the RANSAC validity extent (`path_x_max`, clamped to 10–60 m; 40 m fallback), with tangent-yaw orientations.
- **`camera_interface`**: new `get_latest_frame_stamp_sec()` accessor (default `-1.0` for sources without timestamps, e.g. V4L2 / video file) so the path can be stamped with the source image time.
- **`vision_pilot` app**: calls `publish_lane_path(...)` each frame alongside the existing `write(...)`.
- **CMake**: link `nav_msgs`/`geometry_msgs` `*__rosidl_typesupport_cpp` (not just `*__rosidl_generator_cpp`) so `get_message_type_support_handle<Path>()` resolves at the final app link.

## Validation

Validated in a CARLA-based closed loop with an Autoware MPC lateral controller following `/vehicle/lane_path` on `Town04_Opt` (daytime highway):

- **Topic contract**: `/vehicle/lane_path` live at ~22–25 Hz — `frame_id=base_link`, nonzero stamp, poses at 1 m spacing from `x=0`, tangent-yaw quaternions.
- **Latency**: perception + transport ~63–70 ms end to end.
- **Closed loop**: MPC follows the path and stays in-lane for **~490 m** on Town04_Opt before departing at an unguided T-junction (route ambiguity, a documented non-goal — there is no global route planner in this loop).

## Before / After

Both clips are the same map (`Town04_Opt`, daytime) under the same CARLA UE5 + Autoware MPC rig; only the lateral reference source differs. Watch the orange lane-departure banner and the green drivable-path overlay.

**Before — MPC follows the raw steering command (`/vehicle/steering_cmd`)**

The ego oscillates in a bounded limit cycle (±0.3–0.7 m): the lane-departure banner flips Left↔Right and the drivable path swings side to side.

https://github.com/user-attachments/assets/205f00b4-7b09-4e15-b41c-dffc5befdb2b

**After — MPC follows the new `/vehicle/lane_path` (`nav_msgs/Path`)**

The MPC tracks the published lane center smoothly — the wobble is gone.

https://github.com/user-attachments/assets/bc8ac7a0-3b52-41e9-85a8-f3ea10d23d0a

## Notes

- Draft: the closed-loop numbers above come from an external CARLA + Autoware integration; this PR itself only adds the publisher and its plumbing.
- Non-ROS 2 middleware interfaces inherit the default no-op and are unchanged.
