### PR TITLE
feat: add --no-window flag to run the local display headless

### DIFF
--- a/VisionPilot/app/vision_pilot.cpp
+++ b/VisionPilot/app/vision_pilot.cpp
@@ -47,6 +47,7 @@ int main(int argc, char** argv)
     {
         const std::string arg(argv[i]);
         if (arg == "--debug-viz") debug_viz = true;
+        else if (arg == "--no-window") show_window = false;
     }
 
     std::shared_ptr<CameraInterface> camera_interface;
@@ -99,7 +100,7 @@ int main(int argc, char** argv)
     }
 
     // ── Initialize display ────────────────────────────────────────────────────
-    visualization::Visualization visualization({cfg.webrtc_on, cfg.webrtc_port});
+    visualization::Visualization visualization({cfg.webrtc_on, cfg.webrtc_port, show_window});
 
     const cv::Size net_size(vm::AutoDrive::NET_W, vm::AutoDrive::NET_H);
     cv::Mat frame, warped, resized;

--- a/VisionPilot/modules/visualization/include/visualization/local_display.hpp
+++ b/VisionPilot/modules/visualization/include/visualization/local_display.hpp
@@ -8,11 +8,17 @@ namespace visualization
     class LocalDisplay : public VisualInterface
     {
     public:
-        LocalDisplay();
+        // show_window == false runs headless: no OpenCV window is created and
+        // render_frame() becomes a no-op. This keeps VisionPilot usable in
+        // environments without a display (e.g. containers, CI).
+        explicit LocalDisplay(bool show_window = true);
         ~LocalDisplay();
 
         bool render_frame(const cv::Mat& display_frame) override;
         bool stop() override;
+
+    private:
+        bool show_window_;
     };
 }
 

--- a/VisionPilot/modules/visualization/include/visualization/visualization.hpp
+++ b/VisionPilot/modules/visualization/include/visualization/visualization.hpp
@@ -82,6 +82,7 @@ struct Config
 {
     bool webrtc_on = false;
     int webrtc_port;
+    bool show_window = true;   // false → LocalDisplay runs headless (no window)
 };
 
 void init_production_assets(const std::string& icons_dir = "");

--- a/VisionPilot/modules/visualization/src/local_display.cpp
+++ b/VisionPilot/modules/visualization/src/local_display.cpp
@@ -4,9 +4,11 @@
 
 namespace visualization
 {
-    LocalDisplay::LocalDisplay()
+    LocalDisplay::LocalDisplay(bool show_window)
+        : show_window_(show_window)
     {
-        cv::namedWindow("VisionPilot", cv::WINDOW_NORMAL);
+        if (show_window_)
+            cv::namedWindow("VisionPilot", cv::WINDOW_NORMAL);
     }
 
     LocalDisplay::~LocalDisplay()
@@ -16,6 +18,8 @@ namespace visualization
 
     bool LocalDisplay::render_frame(const cv::Mat& display_frame)
     {
+        if (!show_window_)
+            return true;
         cv::resizeWindow("VisionPilot", display_frame.cols, display_frame.rows);
         cv::imshow("VisionPilot", display_frame);
         cv::waitKey(1);

--- a/VisionPilot/modules/visualization/src/visualization.cpp
+++ b/VisionPilot/modules/visualization/src/visualization.cpp
@@ -621,7 +621,7 @@ Visualization::Visualization(Config cfg)
         static_cast<WebRTCStreamer*>(visual_interface.get())->init(cfg.webrtc_port);
     } else
     {
-        visual_interface = std::make_unique<LocalDisplay>();
+        visual_interface = std::make_unique<LocalDisplay>(cfg.show_window);
     }
 }
 


### PR DESCRIPTION
### Problem

`LocalDisplay`'s constructor calls `cv::namedWindow()` unconditionally, so `Visualization` opens a window on every run regardless of `visualization_on`. On a host with no display (a headless container, a CI runner) that call aborts the process at startup, even when no frame is ever shown.

### Change

`main()` already declared a `show_window` flag but never used it. This wires it to a new `--no-window` CLI option and threads it through `visualization::Config` into `LocalDisplay`; when `show_window` is false, no window is created and `render_frame()` becomes a no-op. The default (window-shown) path is unchanged, and the previously-unused variable is now live.

### Context

Found while running VisionPilot headless as a CPU inference smoke test in an OCI container (Autoware Open AD Kit / AutoSD). This is a source-only change; `--no-window` gives that scenario a first-class opt-in switch instead of relying on a display simply being absent.
