### PR TITLE
fix: return a zero exit code on clean shutdown

### DIFF
--- a/VisionPilot/app/vision_pilot.cpp
+++ b/VisionPilot/app/vision_pilot.cpp
@@ -178,5 +178,8 @@ int main(int argc, char** argv)
         }
     }
 
-    return visualization.stop();
+    // stop() returns true on a clean shutdown; translate that to a 0 exit code
+    // so VisionPilot can be supervised as a batch/oneshot job (a successful run
+    // must not exit non-zero).
+    return visualization.stop() ? 0 : 1;
 }


### PR DESCRIPTION
### Problem

`main()` ends with `return visualization.stop();`. `stop()` returns `true` on a clean shutdown, so a successful run exits with status 1 — any supervisor (systemd `Type=oneshot`, CI, a batch runner) sees the run as failed.

### Change

Map a clean shutdown (`stop() == true`) to exit code 0, and a failed `stop()` to 1.

### Context

Exercised as a systemd oneshot in a headless container (Open AD Kit / AutoSD smoke gate): with this change a completed inference run reports success (exit 0); without it the unit is marked failed despite a clean run.
