### PR TITLE
fix(docker): install ROS2 runtime libs in the CPU image

### DIFF
--- a/VisionPilot/docker/Dockerfile.cpu
+++ b/VisionPilot/docker/Dockerfile.cpu
@@ -101,6 +101,7 @@ RUN mkdir build && cd build \
 
 # runtime
 FROM ubuntu:${UBUNTU_VERSION} AS runtime
+ARG ENABLE_ROS2
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -124,6 +125,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libblas3 \
         libcppad-lib1456.0t64 \
     && rm -rf /var/lib/apt/lists/*
+
+# ROS2 Jazzy runtime libs — only needed when built with ROS2 support (ENABLE_ROS2=ON).
+# Mirrors the builder-stage install so all transitive apt dependencies (fastrtps,
+# tinyxml2, python3, etc.) are present here too, not just in the builder image.
+RUN if [ "$ENABLE_ROS2" = "ON" ]; then \
+        apt-get update && apt-get install -y --no-install-recommends \
+            curl \
+        && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+            -o /usr/share/keyrings/ros-archive-keyring.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+            > /etc/apt/sources.list.d/ros2.list \
+        && apt-get update && apt-get install -y --no-install-recommends \
+            ros-jazzy-ros-base \
+            ros-jazzy-cv-bridge \
+            ros-jazzy-image-transport \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# ROS2 apt packages don't register /opt/ros/jazzy/lib with ldconfig — normally
+# `setup.bash` sets LD_LIBRARY_PATH for you, but ENTRYPOINT runs the binary
+# directly with no shell in between to source it. Set it explicitly instead.
+ENV LD_LIBRARY_PATH="/opt/ros/jazzy/lib:${LD_LIBRARY_PATH}"
 
 RUN mkdir -p /usr/share/visionpilot
 


### PR DESCRIPTION
Closes #381.

The CPU image built with `--ros2` could not start. The build stage installs ROS2 Jazzy, but the runtime stage never did, so the binary was copied into an image that had no rclcpp and exited immediately with "librclcpp.so: cannot open shared object file".

This adds to the runtime stage of `Dockerfile.cpu` the same three things the GPU `Dockerfile` already has: the `ENABLE_ROS2` argument, the conditional install of `ros-jazzy-ros-base`, `cv-bridge` and `image-transport`, and `LD_LIBRARY_PATH` pointing at `/opt/ros/jazzy/lib`. The last one matters because the entrypoint runs the binary directly, with no shell in between to source `setup.bash`.

I checked this against current main before changing anything, and the problem is still there, so the report is still valid.

Testing:

- `./build.sh --cpu --ros2` builds and the image now starts. `ldd` on the binary resolves everything, with librclcpp coming from `/opt/ros/jazzy/lib`.
- Ran it against a live CARLA 0.9.16 session. It subscribes to the camera topic and publishes steering and throttle as expected.
- `./build.sh --cpu` without ROS2 is unaffected, same size as before and no ROS2 files in the image.

The image only grows when ROS2 is enabled, from 2.0 GB to 2.37 GB, which is the cost of the ROS2 packages themselves.
