### PR TITLE
docs: document ENABLE_OCCUPANCY for source and Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,18 @@ or with ROS2 support
   cmake -DONNXRUNTIME_ROOT=<ONNX_RUNTIME_ROOT_PATH> -DENABLE_ROS2_INTERFACE=ON ../
 ```
 
+or with the optional Occupancy BEV window (heuristic 3D / bird's-eye panel beside the HUD; default is OFF):
+
+```bash
+  cmake -DONNXRUNTIME_ROOT=<ONNX_RUNTIME_ROOT_PATH> -DENABLE_OCCUPANCY=ON ../
+```
+
 ```bash
   make
 ```
 
 This will build the project and create VisionPilot executable inside the build directory.
+See `VisionPilot/modules/visualization/README.md` for Occupancy controls (orbit / pan / zoom).
 
 #### Run Vision Pilot on test data and visualize outputs
 
@@ -249,7 +256,7 @@ VisionPilot
 
 To run Vision Pilot inside a Docker container, build the container using the Dockerfiles provided in the docker
 directory of the repository.
-Docker containers can be built with GPU/CPU support, and NO_ROS2/ROS2 support.
+Docker containers can be built with GPU/CPU support, NO_ROS2/ROS2 support, and optional Occupancy BEV support.
 
 To build the container, go to the docker subdirectory and run the following commands:
 
@@ -263,6 +270,12 @@ to build with CPU support
 
 ```bash
   ./build.sh --cpu
+```
+
+to enable the optional Occupancy BEV window (pass alongside `--gpu` or `--cpu`):
+
+```bash
+  ./build.sh --gpu --occupancy
 ```
 
 To run the container use the `run.sh` script. For example to run the container with CPU support

--- a/VisionPilot/docker/build.sh
+++ b/VisionPilot/docker/build.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 #
 # Build the VisionPilot Docker image, choosing GPU or CPU variant and
-# optionally enabling ROS2 support.
+# optionally enabling ROS2 and/or Occupancy BEV support.
 #
 # Usage:
-#   ./build.sh [--gpu|--cpu] [--ros2] [--no-cache] [--tag <name>]
+#   ./build.sh [--gpu|--cpu] [--ros2] [--occupancy] [--no-cache] [--tag <name>]
 #
 # Examples:
-#   ./build.sh                    # CPU build, ROS2 off (defaults)
-#   ./build.sh --gpu              # GPU build, ROS2 off
-#   ./build.sh --gpu --ros2       # GPU build, ROS2 on
-#   ./build.sh --cpu --no-cache   # CPU build, force a clean rebuild
+#   ./build.sh                         # CPU build, ROS2 off, Occupancy off (defaults)
+#   ./build.sh --gpu                   # GPU build, ROS2 off
+#   ./build.sh --gpu --ros2            # GPU build, ROS2 on
+#   ./build.sh --gpu --occupancy       # GPU build with Occupancy BEV window
+#   ./build.sh --cpu --no-cache        # CPU build, force a clean rebuild
 #   ./build.sh --gpu --tag myimg:latest   # custom tag instead of the default
 
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Document `-DENABLE_OCCUPANCY=ON` for source builds in the top-level README
- Document `./build.sh --occupancy` for Docker GPU/CPU images
- Update `VisionPilot/docker/build.sh` usage/examples to include the `--occupancy` flag

Follow-up to #392 so users can discover how to enable the Occupancy BEV window after the feature landed.

## Test plan
- [ ] Confirm README Option 1 cmake snippet renders correctly
- [ ] Confirm README Option 3 documents `./build.sh --gpu --occupancy`
- [ ] `./build.sh --help` / header comments mention `--occupancy`