### PR TITLE
Feat/lateral rate pf

### DIFF
--- a/VisionPilot/app/vision_pilot.cpp
+++ b/VisionPilot/app/vision_pilot.cpp
@@ -153,11 +153,14 @@ int main(int argc, char** argv)
                 cte, epsi, kappa, ego_v, has_cipo, cipo_v, cipo_dist);
 
             VP_INFO(
-                "plan: tyre=%.4f rad  accel=%.3f m/s²  |  cte=%.2fm(raw=%.2fm)  |  cipo=%s  dist=%.1f m  vel=%+.2f m/s",
+                "plan: tyre=%.4f rad  accel=%.3f m/s²  |  cte=%.2fm(raw=%.2fm) cte_dot=%+.2fm/s  epsi=%.3f epsi_dot=%+.3frad/s  |  cipo=%s  dist=%.1f m  vel=%+.2f m/s",
                 plan.steering.empty() ? 0.0 : plan.steering[1],
                 plan.acceleration,
                 cte,
                 raw_cte,
+                r->lateral.cte_rate_mps,
+                epsi,
+                r->lateral.yaw_rate_rps,
                 has_cipo ? "true" : "false",
                 cipo_dist,
                 r->cipo.velocity_ms);

--- a/VisionPilot/modules/debug/src/debug_draw.cpp
+++ b/VisionPilot/modules/debug/src/debug_draw.cpp
@@ -540,9 +540,11 @@ static void draw_hud_panel(cv::Mat& img, const DebugView& v, const OverlayLayout
     y = py + 16;
     text(c3x, y, "FUSED LATERAL", kClrFusedLat); y += lineH;
     if (v.lateral.valid) {
-        text(c3x, y, "CTE       " + fd(v.lateral.cte_m, 2) + " m",
+        text(c3x, y, "CTE       " + fd(v.lateral.cte_m, 2) + " m  "
+                     + fd(v.lateral.cte_rate_mps, 2) + " m/s",
              kClrFusedLat, kNorm, kBold); y += lineH;
-        text(c3x, y, "yaw       " + fd(v.lateral.yaw_rad, 3) + " rad",
+        text(c3x, y, "yaw       " + fd(v.lateral.yaw_rad, 3) + " rad  "
+                     + fd(v.lateral.yaw_rate_rps, 3) + " rad/s",
              kClrFusedLat, kNorm, kBold); y += lineH;
         text(c3x, y, "curvature " + fd(v.lateral.curvature, 4) + " 1/m",
              kClrFusedLat, kNorm, kBold);

--- a/VisionPilot/modules/logging/src/logger.cpp
+++ b/VisionPilot/modules/logging/src/logger.cpp
@@ -114,9 +114,11 @@ void log_inference(const visionpilot::models::InferenceFrameResult& r) {
 	// Fusion / Safety Guardian
 	log_scalar("fusion/cipo/distance_m",   r.cipo.distance_m);    // in-path object distance
 	log_scalar("fusion/cipo/velocity_ms",  r.cipo.velocity_ms);   // in-path object speed
-	log_scalar("fusion/lateral/cte_m",     r.lateral.cte_m);      // cross-track error
-	log_scalar("fusion/lateral/yaw_rad",   r.lateral.yaw_rad);    // yaw error
-	log_scalar("fusion/lateral/curvature", r.lateral.curvature);  // curvature
+	log_scalar("fusion/lateral/cte_m",       r.lateral.cte_m);        // cross-track error
+	log_scalar("fusion/lateral/cte_rate_mps", r.lateral.cte_rate_mps); // cte rate
+	log_scalar("fusion/lateral/yaw_rad",     r.lateral.yaw_rad);      // yaw error
+	log_scalar("fusion/lateral/yaw_rate_rps", r.lateral.yaw_rate_rps); // yaw-error rate
+	log_scalar("fusion/lateral/curvature",   r.lateral.curvature);    // curvature
 
 	// BEV coords of filtered path, sampled from y = ax^2 + bx + c in
 	// world/BEV frame (x = forward (m), y = lateral (m, left as +)).

--- a/VisionPilot/modules/safety_guardian/fusion/include/fusion/lateral_fusion.hpp
+++ b/VisionPilot/modules/safety_guardian/fusion/include/fusion/lateral_fusion.hpp
@@ -20,7 +20,9 @@ struct LateralFusionEstimate {
 
     // ── Particle-filter tracked outputs (ready for planning) ──────────────────
     float cte_m          = 0.f;   // cross-track error [m]; +ve = ego right of path
+    float cte_rate_mps   = 0.f;   // d(cte)/dt [m/s]
     float yaw_rad        = 0.f;   // yaw error [rad];  +ve = path heading left
+    float yaw_rate_rps   = 0.f;   // d(yaw)/dt [rad/s]
     float cte_stddev_m   = 0.f;
     float yaw_stddev_rad = 0.f;
 
@@ -51,8 +53,8 @@ struct LateralFusionEstimate {
 //    2. 2nd-order polynomial RANSAC on world points:
 //         y_lateral = a·x² + b·x + c
 //       → CTE = c, Yaw = atan(b), Curvature = median κ(x) at waypoint x in [curv_x_min, curv_x_max]
-//    3. CTE/Yaw particle filter: state [cte, yaw], random-walk process,
-//       Gaussian update from step-2 when path is valid.
+//    3. CTE/Yaw particle filter: state [cte, cte_dot, epsi, epsi_dot],
+//       constant-velocity predict; measure cte/epsi when path is valid.
 //    4. Curvature particle filter: state [curv], fuses
 //       a) path curvature from step-2  (when path_valid)
 //       b) AutoDrive curvature_raw * ad_curvature_scale  (when drive.valid)
@@ -63,10 +65,12 @@ public:
         int   n_particles            = 300;
         float dt_s                   = 0.10f;   // nominal dt; overridden per-call
 
-        // Process noise (random-walk, scaled by dt internally)
-        float proc_noise_cte_m       = 0.05f;   // allows ~0.05m/s RMS drift for smooth tracking
-        float proc_noise_yaw_rad     = 0.01f;
-        float proc_noise_curv        = 0.002f;
+        // Process noise (scaled by dt internally)
+        float proc_noise_cte_m         = 0.02f;   // small position walk on top of CV model
+        float proc_noise_cte_rate_mps  = 0.15f;   // cte_dot random-walk [m/s²-ish]
+        float proc_noise_yaw_rad       = 0.005f;
+        float proc_noise_yaw_rate_rps  = 0.05f;   // epsi_dot random-walk
+        float proc_noise_curv          = 0.002f;
 
         // Camera mounting offset compensation.  Set to the observed steady-state
         // CTE on a straight road (camera not at vehicle centreline).
@@ -147,8 +151,8 @@ private:
     // Project a single image point (u,v) → (x_forward [m], y_lateral [m])
     static std::pair<float, float> project_world(const cv::Mat& H, float u, float v);
 
-    // ── CTE / Yaw particle filter  [state: cte, yaw] ─────────────────────────
-    struct CYParticle { float cte, yaw, log_w; };
+    // ── CTE / Yaw particle filter  [cte, cte_dot, epsi, epsi_dot] ─────────────
+    struct CYParticle { float cte, cte_dot, yaw, yaw_dot, log_w; };
     void  cy_predict(float dt);
     void  cy_update(float meas_cte, float noise_cte,
                     float meas_yaw, float noise_yaw);

--- a/VisionPilot/modules/safety_guardian/fusion/src/lateral_fusion.cpp
+++ b/VisionPilot/modules/safety_guardian/fusion/src/lateral_fusion.cpp
@@ -103,10 +103,12 @@ LateralFusionEstimate LateralFusion::update(
     // ── Step 6: Extract posterior means ──────────────────────────────────────
     if (cy_init_ && !cy_.empty()) {
         const auto w = linear_weights(cy_);
-        float mean_cte = 0.f, mean_yaw = 0.f;
+        float mean_cte = 0.f, mean_cte_dot = 0.f, mean_yaw = 0.f, mean_yaw_dot = 0.f;
         for (std::size_t i = 0; i < cy_.size(); ++i) {
-            mean_cte += w[i] * cy_[i].cte;
-            mean_yaw += w[i] * cy_[i].yaw;
+            mean_cte     += w[i] * cy_[i].cte;
+            mean_cte_dot += w[i] * cy_[i].cte_dot;
+            mean_yaw     += w[i] * cy_[i].yaw;
+            mean_yaw_dot += w[i] * cy_[i].yaw_dot;
         }
         float var_cte = 0.f, var_yaw = 0.f;
         for (std::size_t i = 0; i < cy_.size(); ++i) {
@@ -116,7 +118,9 @@ LateralFusionEstimate LateralFusion::update(
             var_yaw += w[i] * dy * dy;
         }
         est.cte_m          = mean_cte;
+        est.cte_rate_mps   = mean_cte_dot;
         est.yaw_rad        = mean_yaw;
+        est.yaw_rate_rps   = mean_yaw_dot;
         est.cte_stddev_m   = std::sqrt(std::max(0.f, var_cte));
         est.yaw_stddev_rad = std::sqrt(std::max(0.f, var_yaw));
         est.valid          = true;
@@ -154,9 +158,9 @@ LateralFusionEstimate LateralFusion::update(
         else
             std::snprintf(ad_buf, sizeof(ad_buf), "(none)");
 
-        VP_INFO("[Lateral] Path: %s | AD-κ=%s | Fused CTE=%.2fm yaw=%.3frad κ=%.4f",
+        VP_INFO("[Lateral] Path: %s | AD-κ=%s | Fused CTE=%.2fm (%.2fm/s) yaw=%.3frad (%.3frad/s) κ=%.4f",
                 path_buf, ad_buf,
-                est.cte_m, est.yaw_rad, est.curvature);
+                est.cte_m, est.cte_rate_mps, est.yaw_rad, est.yaw_rate_rps, est.curvature);
     }
 
     return est;
@@ -348,15 +352,29 @@ void LateralFusion::cy_init(float cte, float yaw)
     cy_.resize(static_cast<std::size_t>(N));
     std::normal_distribution<float> nc(cte, cfg_.meas_noise_cte_m);
     std::normal_distribution<float> ny(yaw, cfg_.meas_noise_yaw_rad);
-    for (auto& p : cy_) { p.cte = nc(rng_); p.yaw = ny(rng_); p.log_w = 0.f; }
+    std::normal_distribution<float> ncd(0.f, cfg_.proc_noise_cte_rate_mps);
+    std::normal_distribution<float> nyd(0.f, cfg_.proc_noise_yaw_rate_rps);
+    for (auto& p : cy_) {
+        p.cte = nc(rng_); p.cte_dot = ncd(rng_);
+        p.yaw = ny(rng_); p.yaw_dot = nyd(rng_);
+        p.log_w = 0.f;
+    }
     cy_init_ = true;
 }
 
 void LateralFusion::cy_predict(float dt)
 {
-    std::normal_distribution<float> nc(0.f, cfg_.proc_noise_cte_m  * std::sqrt(dt / cfg_.dt_s));
-    std::normal_distribution<float> ny(0.f, cfg_.proc_noise_yaw_rad * std::sqrt(dt / cfg_.dt_s));
-    for (auto& p : cy_) { p.cte += nc(rng_); p.yaw += ny(rng_); }
+    const float s = std::sqrt(dt / cfg_.dt_s);
+    std::normal_distribution<float> nc(0.f, cfg_.proc_noise_cte_m * s);
+    std::normal_distribution<float> ncd(0.f, cfg_.proc_noise_cte_rate_mps * s);
+    std::normal_distribution<float> ny(0.f, cfg_.proc_noise_yaw_rad * s);
+    std::normal_distribution<float> nyd(0.f, cfg_.proc_noise_yaw_rate_rps * s);
+    for (auto& p : cy_) {
+        p.cte     += p.cte_dot * dt + nc(rng_);
+        p.cte_dot += ncd(rng_);
+        p.yaw     += p.yaw_dot * dt + ny(rng_);
+        p.yaw_dot += nyd(rng_);
+    }
 }
 
 void LateralFusion::cy_update(float meas_cte, float noise_cte,


### PR DESCRIPTION
## Summary
Lateral particle filter now tracks CTE/yaw and their rates so we get smoothed cte_dot / epsi_dot for free. Curvature filter is unchanged (still 1-state, no curv rate).

 ## PF details (CTE / yaw rates)
Particles -  300
State -[cte, cte_dot, epsi, epsi_dot]
Model - constant-velocity
dt - 0.10 s (nominal)
Measure - CTE + yaw only (from path fit)
Rates - inferred from particles (not measured)
Output -weighted mean of all 4 states

## Predict

cte      += cte_dot * dt + noise
cte_dot  += noise
epsi     += epsi_dot * dt + noise
epsi_dot += noise
Process noise scaled by sqrt(dt / 0.10).

# Noise (1σ)

proc_noise_cte_m
0.02 m
proc_noise_cte_rate_mps
0.15 m/s
proc_noise_yaw_rad
0.005 rad
proc_noise_yaw_rate_rps
0.05 rad/s
meas_noise_cte_m
0.15 m
meas_noise_yaw_rad
0.05 rad